### PR TITLE
Visualise core access

### DIFF
--- a/src/containers/app/App.css
+++ b/src/containers/app/App.css
@@ -72,6 +72,7 @@ main {
   margin-left: 215px;
   background: rgba(240,240,240,1);
   min-height: 665px;
+  height: 100%;
   padding: 40px;
   color: #424a5d;
   font-size: 16px;

--- a/src/containers/parser/index.js
+++ b/src/containers/parser/index.js
@@ -4,7 +4,8 @@ import { connect } from 'react-redux'
 import './parser.css';
 import {
   parse,
-  setStandard
+  setStandard,
+  save
 } from '../../modules/parser'
 
 const messageTypeToString = (messageType) => {
@@ -21,6 +22,7 @@ const messageTypeToString = (messageType) => {
 }
 
 const Parser = props => (
+
   <div>
     <h1>Redcode Parser</h1>
     <div>
@@ -31,13 +33,14 @@ const Parser = props => (
           <option value="1">ICWS'88</option>
           <option value="2">ICWS'94-draft</option>
         </select>
+        {props.currentParseResult && <button onClick={() => props.save()}>Save Warrior</button>}
       </p>
       <textarea onChange={e => props.parse(e.target.value)} value={props.redcode}></textarea>
-      <textarea value={props.parseResult && props.parseResult.warrior}></textarea>
+      <textarea value={props.currentParseResult && props.currentParseResult.warrior}></textarea>
       <div className="errors">
         <ul>
           {
-            props.parseResult.messages.map((item) => {
+             props.currentParseResult.messages && props.currentParseResult.messages.map((item) => {
                 return <li key={item} >{`[${item.position.line} , ${item.position.char}] ${messageTypeToString(item.type)} ${item.text}`}</li>
             })
           }
@@ -48,7 +51,8 @@ const Parser = props => (
 )
 
 const mapStateToProps = state => ({
-  parseResult: state.parser.parseResult,
+  currentParseResult: state.parser.currentParseResult,
+  parseResults: state.parser.parseResults,
   isParsing: state.parser.isParsing,
   standardId: state.parser.standardId,
   redcode: state.parser.redcode
@@ -56,7 +60,8 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => bindActionCreators({
   parse,
-  setStandard
+  setStandard,
+  save
 }, dispatch)
 
 export default connect(

--- a/src/containers/simulator/cell.css
+++ b/src/containers/simulator/cell.css
@@ -1,0 +1,60 @@
+.coreAccess .cell {
+  font-size: 2em;
+}
+
+.cell {
+  display: inline-block;
+  width: 49px;
+  height: 49px;
+  border-right: 1px solid #ccc;
+  border-bottom: 1px solid #ccc;
+  text-align: center;
+}
+
+.cell-default {
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+  color:rgba(240,240,240, 1);
+}
+
+.cell-read {
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+  color: red;
+}
+
+.cell-write {
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+  color: red;
+}
+
+.cell-white {
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+  background-color: #fff;
+  color: #fff;
+  transition: background-color 2000ms linear;
+}
+
+.cell-red {
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+  background-color: red;
+  color: red;
+  transition: background-color 2000ms linear;
+}
+
+.cell-green {
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+  background-color: green;
+  color: green;
+  transition: background-color 2000ms linear;
+}

--- a/src/containers/simulator/cell.js
+++ b/src/containers/simulator/cell.js
@@ -1,6 +1,8 @@
 import React from 'react'
 import { corewar } from 'corewar';
 
+import './cell.css';
+
 const Cell = props => {
 
   let css = `cell-${props.data ? props.data.colour : 'default'}`;

--- a/src/containers/simulator/cell.js
+++ b/src/containers/simulator/cell.js
@@ -3,13 +3,15 @@ import { corewar } from 'corewar';
 
 const Cell = props => {
 
-  let css = `cell-${props.data ? props.data : 'default'}`;
+  let css = `cell-${props.data ? props.data.colour : 'default'}`;
   let label = props.data ? props.data.label : '';
   let icon = props.data ? props.data.icon : '';
   let address = props.data ? props.data.address : '';
 
   return <div className={`cell`}>
-    {label ? label : icon}
+    <span className={`${css}`}>
+      {label ? label : icon}
+    </span>
   </div>
 }
 

--- a/src/containers/simulator/core.js
+++ b/src/containers/simulator/core.js
@@ -3,7 +3,7 @@ import Cell from './cell';
 
 const Core = props => {
   return <div className="core">
-    {props.data && props.data.map((data, i) =>
+    {props.data  && props.data.map((data, i) =>
       {
       return <Cell key={i} data={data} />
     })}

--- a/src/containers/simulator/core.js
+++ b/src/containers/simulator/core.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Cell from './cell';
 
 const Core = props => {
-  return <div className="core">
+  return <div className={`core ${props.type}`}>
     {props.data  && props.data.map((data, i) =>
       {
       return <Cell key={i} data={data} />

--- a/src/containers/simulator/index.js
+++ b/src/containers/simulator/index.js
@@ -18,6 +18,7 @@ const Simulator = props => {
       <textarea value={props.redcode} readOnly="readOnly" />
       <Core data={props.core} />
       <Core data={props.coreAccess} />
+      <Core data={props.taskExecution} />
     </div>
   </div>
 }

--- a/src/containers/simulator/index.js
+++ b/src/containers/simulator/index.js
@@ -16,9 +16,9 @@ const Simulator = props => {
     {props.isInitialised && <button onClick={() => props.step()}>Step</button>}
     <div>
       <textarea value={props.redcode} readOnly="readOnly" />
-      <Core data={props.core} />
-      <Core data={props.coreAccess} />
-      <Core data={props.taskExecution} />
+      {/* <Core type='core' data={props.core} /> */}
+      <Core type='coreAccess' data={props.coreAccess} />
+      <Core type='tasks' data={props.taskExecution} />
     </div>
   </div>
 }

--- a/src/containers/simulator/index.js
+++ b/src/containers/simulator/index.js
@@ -12,7 +12,7 @@ const Simulator = props => {
   console.log(props);
   return <div>
     <h1>Core simulator</h1>
-    {props.redcode && <button onClick={() => props.init(props.standardId, props.parseResult)}>Initialise Simulator</button>}
+    {props.redcode && <button onClick={() => props.init(props.standardId, props.parseResults)}>Initialise Simulator</button>}
     {props.isInitialised && <button onClick={() => props.step()}>Step</button>}
     <div>
       <textarea value={props.redcode} readOnly="readOnly" />
@@ -25,7 +25,7 @@ const Simulator = props => {
 
 const mapStateToProps = state => ({
   redcode: state.parser.redcode,
-  parseResult: state.parser.parseResult,
+  parseResults: state.parser.parseResults,
   standardId: state.parser.standardId,
   core: state.simulator.core,
   coreAccess: state.simulator.coreAccess,

--- a/src/containers/simulator/simulator.css
+++ b/src/containers/simulator/simulator.css
@@ -13,12 +13,12 @@ textarea {
 .cell {
   display: inline-block;
   width: 49px;
-  height: 34px;
+  height: 49px;
   border-right: 1px solid #ccc;
   border-bottom: 1px solid #ccc;
   text-align: center;
-  padding-top: 15px;
   font-size: 0.8em;
+  position: relative;
 }
 
 button {
@@ -36,3 +36,22 @@ button:hover {
   cursor: pointer;
   border-color: #B5F44A;
 }
+
+.cell-read {
+  color: red;
+  font-size: 2em;
+}
+
+.cell-write {
+  color: red;
+  font-size: 2em;
+}
+
+.cell-white {
+  display: inline-block;
+  width: 100%;
+  height: 100%;
+  background-color: #fff;
+  transition: background-color 2000ms linear;
+}
+

--- a/src/containers/simulator/simulator.css
+++ b/src/containers/simulator/simulator.css
@@ -10,17 +10,6 @@ textarea {
   float: right;
 }
 
-.cell {
-  display: inline-block;
-  width: 49px;
-  height: 49px;
-  border-right: 1px solid #ccc;
-  border-bottom: 1px solid #ccc;
-  text-align: center;
-  font-size: 0.8em;
-  position: relative;
-}
-
 button {
   border: 1px solid #ccc;
   margin-right: 1em;
@@ -35,23 +24,5 @@ button {
 button:hover {
   cursor: pointer;
   border-color: #B5F44A;
-}
-
-.cell-read {
-  color: red;
-  font-size: 2em;
-}
-
-.cell-write {
-  color: red;
-  font-size: 2em;
-}
-
-.cell-white {
-  display: inline-block;
-  width: 100%;
-  height: 100%;
-  background-color: #fff;
-  transition: background-color 2000ms linear;
 }
 

--- a/src/modules/parser.js
+++ b/src/modules/parser.js
@@ -13,7 +13,7 @@ const initialState = {
   },
   warrior: '',
   standardId: 2,
-  redcode: ''
+  redcode: 'MOV 0, 1'
 }
 
 

--- a/src/modules/parser.js
+++ b/src/modules/parser.js
@@ -3,17 +3,16 @@ import { corewar } from "corewar";
 export const PARSE_REQUESTED = 'parser/INCREMENT_REQUESTED'
 export const PARSE = 'parser/INCREMENT'
 export const SET_STANDARD = 'parser/SET_STANDARD'
+export const SAVE = 'parser/SAVE'
 
 // state
 const initialState = {
   isParsing: false,
-  parseResult: {
-    messages: [],
-    tokens: []
-  },
-  warrior: '',
+  currentParseResult: {},
+  parseResults: [],
   standardId: 2,
-  redcode: 'MOV 0, 1'
+  redcode: 'MOV 0, 1',
+  warrior: ''
 }
 
 
@@ -33,10 +32,16 @@ export default (state = initialState, action) => {
         isParsing: true
       }
 
+    case SAVE:
+      return {
+        ...state,
+        parseResults: insertItem(state.parseResults.length, state.parseResults, state.currentParseResult)
+      }
+
     case PARSE:
       return {
         ...state,
-        parseResult: action.result,
+        currentParseResult: action.result,
         redcode: action.redcode,
         isParsing: false
       }
@@ -46,7 +51,21 @@ export default (state = initialState, action) => {
   }
 }
 
+const insertItem = (index, array, item) => {
+  let newArray = array.slice();
+  newArray.splice(index, 0, item);
+  return newArray;
+}
+
 // actions
+export const save = () => {
+  return dispatch => {
+    dispatch({
+      type: SAVE
+    })
+  }
+};
+
 export const parse = (redcode) => {
 
   let result = corewar.parser.parse(redcode);
@@ -74,3 +93,4 @@ export const setStandard = (standardId) => {
     })
   }
 }
+

--- a/src/modules/simulator.js
+++ b/src/modules/simulator.js
@@ -60,12 +60,6 @@ const updateTask = (index, array, item) => {
   return newArray;
 }
 
-const insertItem = (index, array, item) => {
-  let newArray = array.slice();
-  newArray.splice(index, 0, item);
-  return newArray;
-}
-
 const accessTypeToIcon = (accessType) => {
   switch(accessType) {
     case 0:

--- a/src/modules/simulator.js
+++ b/src/modules/simulator.js
@@ -25,14 +25,14 @@ export default (state = initialState, action) => {
         ...state,
         core: action.core,
         coreAccess: action.coreAccess,
-        taskExcution: action.taskExcution,
+        taskExecution: action.taskExecution,
         isInitialised: true
       }
 
     case STEP:
       return {
         ...state,
-        taskExecution: action.taskExecution
+        taskExecution: updateTasks(action.taskExecution, state.taskExecution)
       }
 
     case CORE_ACCESS:
@@ -46,11 +46,27 @@ export default (state = initialState, action) => {
   }
 }
 
+const updateTasks= (tasks, taskExecution) => {
+  let adjustedArray;
+  tasks.forEach(task => {
+    adjustedArray = updateTask(task.address, taskExecution, task)
+  });
+  return adjustedArray;
+}
+
 const updateItem = (index, array, item) => {
   const newArray = array.slice();
   newArray[index] = coreAccessToCell(item);
   return newArray;
 }
+
+const updateTask = (index, array, item) => {
+  const newArray = array.slice();
+  newArray[index] = taskToCell(item);
+  return newArray;
+}
+
+
 
 const insertItem = (index, array, item) => {
   let newArray = array.slice();
@@ -62,12 +78,14 @@ const accessTypeToIcon = (accessType) => {
   switch(accessType) {
     case 0:
      return {
-       name: 'R',
+       name: '¤',
+       css: 'read',
        path: ''
      }
     case 1:
      return {
-       name: 'W',
+       name: '×',
+       css: 'write',
        path: ''
      }
     default:
@@ -84,8 +102,19 @@ const coreAccessToCell = (coreAccess) => {
     address: coreAccess.address,
     label: icon.name,
     icon: icon.icon,
-    colour: ''
+    colour: icon.css
   };
+};
+
+const taskToCell = (task) => {
+
+  return {
+    address: task.address,
+    label: '',
+    icon: task.icon,
+    colour: task.colour
+  }
+
 };
 
 const defaultCell = {
@@ -95,17 +124,27 @@ const defaultCell = {
     icon: ''
 };
 
+const warriorToCellColour = (warriorNumber, warriorIndex) => {
+
+  if(warriorIndex == warriorNumber) {
+    return 'white';
+  } else {
+    return 'red';
+  }
+
+}
+
 const mapStateToExecution = (state) => {
 
+  return state.warriors.map((w, i) =>
+      w.tasks.map(t => {
+        return {
+          address: t.instructionPointer,
+          warrior: i,
+          colour: warriorToCellColour(i, state.warriorIndex)
+        }
+      })).reduce((a, c) => a.concat(c));
 
-  debugger;
-  //TODO: Decide whether this is mapped here or in components
-  state.map((state) => {
-    return {
-      warriorIndex: state.warriorIndex,
-      warriors: state.warriors,
-    }
-  });
 };
 
 const mapCoreToUi = (instructions) => {
@@ -129,6 +168,7 @@ export const init = (standardId, parseResult) => {
   const coreAccess = new Array(simulatorState.core.instructions.length);
   coreAccess.fill(defaultCell, 0, coreAccess.length)
   const taskExecution = new Array(simulatorState.core.instructions.length);
+  taskExecution.fill(defaultCell, 0, taskExecution.length)
 
   return dispatch => {
 
@@ -154,16 +194,16 @@ export const init = (standardId, parseResult) => {
 
 export const step = () => {
 
-  corewar.simulator.step();
-
   const state = corewar.simulator.getState();
 
-  //const taskExecution = mapStateToExecution(state);
+  const taskExecution = mapStateToExecution(state);
+
+  corewar.simulator.step();
 
   return dispatch => {
     dispatch({
       type: STEP,
-      taskExecution: state
+      taskExecution: taskExecution
     })
   }
 }


### PR DESCRIPTION
This PR adds methods to the actions/reducers to handle the visualisation of core access, including remembering the warrior number and moving the current execution.

It also re-orders accessing the core state to be performed prior to taking a step, so the current executing address now seems to be one address behind the most advanced write (using an imp as an example as shown in the image below)

![image](https://user-images.githubusercontent.com/1190042/33230298-83160d52-d1d8-11e7-9ce8-75ee839738c4.png)


NOTE: I've not refactoring this to sensible code yet, I wanted to make sure I was doing the right things before undertaking that!

