### PR TITLE
Remove core reference2

### DIFF
--- a/src/containers/simulator/index.js
+++ b/src/containers/simulator/index.js
@@ -48,7 +48,6 @@ const mapStateToProps = state => ({
   redcode: state.parser.redcode,
   parseResults: state.parser.parseResults,
   standardId: state.parser.standardId,
-  core: state.simulator.core,
   coreAccess: state.simulator.coreAccess,
   taskExecution: state.simulator.taskExecution,
   isInitialised: state.simulator.isInitialised,


### PR DESCRIPTION
I don't think we currently need this reference to `core`.

I want to refactor so that it is not exposed outside the `corewar` library