### PR TITLE
Add round progress indicator

### DIFF
--- a/src/containers/parser/controlButton.css
+++ b/src/containers/parser/controlButton.css
@@ -41,7 +41,7 @@
 
     visibility: hidden;
     background-color: #56CCF2;
-    color: #000000;
+    color: #100E14;
     text-align: center;
     padding: 5px 0;
     border-radius: 10px;

--- a/src/containers/simulator/canvasCore.js
+++ b/src/containers/simulator/canvasCore.js
@@ -72,6 +72,7 @@ class CanvasCore extends Component {
 
   componentWillUnmount() {
     PubSub.unsubscribe('CORE_ACCESS');
+    PubSub.unsubscribe('RESET_CORE');
   }
 
   renderGrid() {

--- a/src/containers/simulator/runProgressIndicator.js
+++ b/src/containers/simulator/runProgressIndicator.js
@@ -1,0 +1,9 @@
+import React from 'react'
+
+const RunProgressIndicator = ({ runProgress }) => (
+  <div className={`progressBar`} style={{width: runProgress+ '%' }}>
+    {/* <span>{`${runProgress} %`}</span> */}
+  </div>
+)
+
+export default RunProgressIndicator

--- a/src/containers/simulator/simulatorContainer.js
+++ b/src/containers/simulator/simulatorContainer.js
@@ -29,6 +29,7 @@ const SimulatorContainer = ({
   isInitialised,
   coreSize,
   coreInfo,
+  runProgress,
   parseResults,
   roundResult,
   init,
@@ -57,7 +58,8 @@ const SimulatorContainer = ({
       finishRound={finishRound}
       setProcessRate={setProcessRate}
       processRate={processRate}
-      processRates={processRates} />
+      processRates={processRates}
+      runProgress={runProgress} />
     <SimulatorStatus
       isRunning={isRunning}
       isInitialised={isInitialised}
@@ -80,7 +82,8 @@ const mapStateToProps = state => ({
   roundResult: state.simulator.roundResult,
   parseResults: state.parser.parseResults,
   processRate: state.simulator.processRate,
-  processRates: state.simulator.processRates
+  processRates: state.simulator.processRates,
+  runProgress: state.simulator.runProgress
 })
 
 const mapDispatchToProps = dispatch => bindActionCreators({

--- a/src/containers/simulator/simulatorControls.css
+++ b/src/containers/simulator/simulatorControls.css
@@ -7,6 +7,29 @@
   grid-template-rows: 1fr;
 }
 
+#runProgressContainer {
+
+  border: 2px solid #56CCF2;
+  border-bottom: none;
+  border-right: none;
+  border-top-left-radius: 10px;
+}
+
+.progressBar {
+  height: 100%;
+  display: inline-block;
+  background-color: #56CCF2;
+  border-top-left-radius: 5px;
+  color: #fff;
+  font-family: 'roboto condensed';
+  text-align: center;
+}
+
+.progressBar span {
+  display: inline-block;
+  padding-top: 0.8em;
+}
+
 #simulatorControls {
 
   grid-column-start: 2;
@@ -20,7 +43,6 @@
   border: 2px solid #56CCF2;
   border-bottom: none;
   border-top-right-radius: 10px;
-  border-top-left-radius: 10px;
   color: #fff;
 }
 
@@ -35,7 +57,7 @@
 
   visibility: hidden;
   background-color: #56CCF2;
-  color: #000000;
+  color: #100E14;
   text-align: center;
   padding: 5px 0;
   border-radius: 10px;

--- a/src/containers/simulator/simulatorControls.js
+++ b/src/containers/simulator/simulatorControls.js
@@ -6,6 +6,7 @@ import ResetControl from './resetControl'
 import StepControl from './stepControl'
 import SpeedControl from './speedControl'
 import FinishRoundControl from './finishRoundControl'
+import RunProgressIndicator from './runProgressIndicator'
 
 import './simulatorControls.css'
 
@@ -13,6 +14,7 @@ const SimulatorControls = ({
   isRunning,
   isInitialised,
   parseResults,
+  runProgress,
   init,
   step,
   run,
@@ -22,6 +24,9 @@ const SimulatorControls = ({
   processRates,
   finishRound }) => (
   <section id="simulatorControlContainer">
+    <div id="runProgressContainer">
+      <RunProgressIndicator runProgress={runProgress}/>
+    </div>
     <div id="simulatorControls" className={isInitialised ? `active` : `inactive`}>
       <SpeedControl
         handleClick={setProcessRate}


### PR DESCRIPTION
Add's a simple progress bar showing the `roundProgress` state property as a blue bar.

![image](https://user-images.githubusercontent.com/1190042/34289265-a21ba1c8-e6e9-11e7-8788-96694c6bb1c3.png)

![image](https://user-images.githubusercontent.com/1190042/34289287-ba73e96a-e6e9-11e7-9f33-7bee623454eb.png)

![image](https://user-images.githubusercontent.com/1190042/34289296-c3fdbfec-e6e9-11e7-90c3-dfda8b394e0f.png)
