### PR TITLE
Display a bar for the warriors current tasks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4115,8 +4115,7 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -5098,6 +5097,11 @@
       "version": "3.3.7",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
       "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA=="
+    },
+    "immutable": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-3.8.2.tgz",
+      "integrity": "sha1-wkOZUUVbs5kT2vKBN28VMOEErfM="
     },
     "import-local": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "chai": "^4.1.2",
     "corewar": "0.0.64",
+    "immutable": "^3.8.2",
     "jest-cli": "^21.2.1",
     "pubsub-js": "^1.5.7",
     "react": "^16.1.1",

--- a/src/components/simulator/canvasCore.js
+++ b/src/components/simulator/canvasCore.js
@@ -1,5 +1,5 @@
-import React, { Component }from 'react'
-import * as PubSub from 'pubsub-js';
+import React, { Component } from 'react'
+import * as PubSub from 'pubsub-js'
 
 const colourPalette = [
   '#EB5757',
@@ -14,7 +14,7 @@ class CanvasCore extends Component {
 
   constructor(props) {
 
-    super(props);
+    super(props)
 
     this.coreSize = props.coreSize;
     this.getCoreInstructions = props.getCoreInstructions;

--- a/src/components/simulator/coreInput.css
+++ b/src/components/simulator/coreInput.css
@@ -22,7 +22,17 @@
   color: #fff;
 
   font-size: 0.8em;
-  padding: 5px;
+
+  display: grid;
+  grid-template-columns: 15px 1fr 15px;
+  grid-template-rows: 5px 1fr 5px 1fr 5px;
+}
+
+.itemName {
+  grid-row-start: 2;
+  grid-row-end: 3;
+
+  padding-left: 1em;
 }
 
 .coreItem:first-child {
@@ -30,18 +40,41 @@
 }
 
 .coreItem .fa {
-  float: right;
-  margin-top: 2px;
   color: #EB5757;
   cursor: pointer;
+
+  grid-row-start: 2;
+  grid-row-end: 5;
+}
+
+.taskCount {
+  grid-row-start: 4;
+  grid-row-end: 5;
+  text-align: right;
+  position: relative;
+
+  display: grid;
+  grid-template-columns: 1fr 4em;
+}
+
+.taskCount span {
+  display: inline-block;
+  grid-column-start: 2;
 }
 
 .inputItem {
-  clear: both;
-  margin-top: 5px;
-  width: 100%;
-  height: 15px;
   display: inline-block;
+  margin-left: 1em;
+  width: 0%;
+  height: 100%;
+  position: absolute;
+  right: 0;
+  grid-column-end: 2;
+}
+
+[class^="coreItem_"] {
+  grid-row-start: 1;
+  grid-row-end: 6;
 }
 
 .coreItem_0 {

--- a/src/components/simulator/coreInput.js
+++ b/src/components/simulator/coreInput.js
@@ -1,19 +1,50 @@
-import React from 'react'
+import React, { Component } from 'react'
+import * as PubSub from 'pubsub-js'
 import FontAwesome from 'react-fontawesome'
+import { List } from 'immutable'
 
 import './coreInput.css'
 
-const CoreInput = ({ parseResults, removeWarrior }) => (
-  <section id="coreInput">
-    {
-      parseResults && parseResults.map((result, i) => (
-        <div className="coreItem" key={`${result.metaData.name}_${i}`}>
-          <span>{result.metaData.name}</span> <FontAwesome name='times' onClick={() => removeWarrior(i)}/>
-          <div className={`inputItem coreItem_${i}`}></div>
-        </div>
-      ))
-    }
-  </section>
-)
+class CoreInput extends Component {
 
+  constructor(props) {
+    super(props)
+
+    this.state = {
+      tasks: List()
+    }
+
+    PubSub.subscribe('TASK_COUNT', (msg, data) => {
+      const newTasks = this.state.tasks.splice(data.warriorId, 1, data.taskCount)
+      this.setState({ tasks: newTasks })
+    })
+  }
+
+  componentWillUnmount() {
+    PubSub.unsubscribe('TASK_COUNT')
+  }
+
+  render() {
+    const { parseResults, removeWarrior } = this.props
+    return <section id="coreInput">
+      {
+        parseResults && parseResults.map((result, i) => {
+          const taskCount = this.state.tasks.get(i)
+          return <div className="coreItem" key={`${result.metaData.name}_${i}`}>
+              <div className={`coreItem_${i}`}></div>
+              <span className={`itemName`}>{result.metaData.name}</span>
+              <FontAwesome name='times' onClick={() => removeWarrior(i)}/>
+              <section className={`taskCount`}>
+                <div className={`inputItem coreItem_${i}`} style={{width: parseInt(taskCount / 8000 * 100 , 10) + '%' }}>
+                </div>
+                <span>{taskCount && taskCount}</span>
+              </section>
+            </div>
+          }
+        )
+      }
+    </section>
+  }
+}
 export default CoreInput
+

--- a/src/components/simulator/runProgressIndicator.js
+++ b/src/components/simulator/runProgressIndicator.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 const RunProgressIndicator = ({ runProgress }) => (
-  <div className={`progressBar`} style={{width: runProgress+ '%' }}>
+  <div className={`progressBar`} style={{width: runProgress + '%' }}>
     {/* <span>{`${runProgress} %`}</span> */}
   </div>
 )

--- a/src/helpers/arrayHelpers.js
+++ b/src/helpers/arrayHelpers.js
@@ -10,3 +10,18 @@ export const removeItem = (index, array) => {
     ...array.slice(index + 1)
   ]
 }
+
+export const replaceItem = (index, array, item) => {
+
+    return array.map((el, i) => {
+      if(i !== index) {
+        return el;
+      }
+
+      return {
+        ...el,
+        ...item
+      }
+    })
+
+}

--- a/src/sagas/parserSagas.js
+++ b/src/sagas/parserSagas.js
@@ -69,7 +69,7 @@ function* removeWarriorSaga({ index }) {
     instructionLimit: instructionLimit,
   };
 
-  const result = removeItem(index, parseResults);
+  const result = yield call(removeItem, index, parseResults);
 
   yield put({ type: REMOVE_WARRIOR, result })
 

--- a/src/tests/helpers/arrayHelpers.test.js
+++ b/src/tests/helpers/arrayHelpers.test.js
@@ -1,0 +1,99 @@
+import { expect } from 'chai'
+
+import { insertItem, removeItem, replaceItem } from './../../helpers/arrayHelpers'
+
+describe('when inserting items into an array', () => {
+
+  const initialArray = [{ a: 1}, { a: 2 }, { a: 3}]
+
+  it('increases the length by one', () => {
+
+    const result = insertItem(3, initialArray, { a: 4 })
+
+    expect(result.length).to.equal(4)
+
+  })
+
+  it('returns a new instance of the array', () => {
+
+    const result = insertItem(3, initialArray, { a: 4 })
+
+    expect(result).to.not.equal(initialArray)
+
+  })
+
+  it('insert the item at the expected index', () => {
+
+    const newItem = { a: 4 }
+    const result = insertItem(2, initialArray, newItem)
+
+    expect(result).to.include(newItem)
+    expect(result[2]).to.equal(newItem)
+
+  })
+
+})
+
+describe('when removing items from an array', () => {
+
+  const initialArray = [{ a: 1}, { a: 2 }, { a: 3}]
+
+
+  it('reduces the length by one', () => {
+
+    const result = removeItem(1, initialArray)
+
+    expect(result.length).to.equal(2)
+
+  })
+
+  it('returns a new instance of the array', () => {
+
+    const result = removeItem(1, initialArray)
+
+    expect(result).to.not.equal(initialArray)
+
+  })
+
+  it('removes the item at the expected index', () => {
+
+    const result = removeItem(1, initialArray)
+
+    expect(result).to.not.contain.include(initialArray[1])
+
+  })
+
+})
+
+describe('when replacing items in an array', () => {
+
+    const initialArray = [{ a: 1}, { a: 2 }, { a: 3}]
+    const newItem = { a: 4 }
+
+    it('keeps the the length the same', () => {
+
+      const result = replaceItem(2, initialArray, newItem)
+
+      expect(result.length).to.equal(3)
+
+    })
+
+    it('returns a new instance of the array', () => {
+
+      const result = replaceItem(2, initialArray, newItem)
+
+      expect(result).to.not.equal(initialArray)
+
+    })
+
+    it('replaces the item at the expected index', () => {
+
+      const result = replaceItem(2, initialArray, newItem)
+
+      //expect(result).to.include(newItem)
+      expect(result).to.not.include(initialArray[2])
+      expect(result[2]).to.deep.equal(newItem)
+
+    })
+
+  })

--- a/src/tests/sagas/parserSaga.test.js
+++ b/src/tests/sagas/parserSaga.test.js
@@ -56,5 +56,3 @@ describe('when testing the parser', () => {
 })
 
 
-
-


### PR DESCRIPTION
Displays a task bar which updates during each round.

It fills from the right hand side as a % width based on the max number of tasks (which is hard coded to 8000 atm)

![image](https://user-images.githubusercontent.com/1190042/34583949-a96c58fc-f191-11e7-8d6f-94b012e61a56.png)

Resolves the task part of  #111 