### PR TITLE
Ensure runProgress is reset on init and make coreInput listen for 0%

### DIFF
--- a/src/components/simulator/coreInput.js
+++ b/src/components/simulator/coreInput.js
@@ -24,18 +24,26 @@ class CoreInput extends Component {
     PubSub.unsubscribe('TASK_COUNT')
   }
 
+  componentWillReceiveProps({ runProgress }) {
+    if(runProgress === 0) {
+      this.setState({ tasks: List() })
+    }
+  }
+
   render() {
     const { parseResults, removeWarrior } = this.props
     return <section id="coreInput">
       {
         parseResults && parseResults.map((result, i) => {
           const taskCount = this.state.tasks.get(i)
+          //TODO: 8000 shoudln't be hardcoded
+          const taskWidth = taskCount ? parseInt(taskCount / 8000 * 100 , 10) : 0
           return <div className="coreItem" key={`${result.metaData.name}_${i}`}>
               <div className={`coreItem_${i}`}></div>
               <span className={`itemName`}>{result.metaData.name}</span>
               <FontAwesome name='times' onClick={() => removeWarrior(i)}/>
               <section className={`taskCount`}>
-                <div className={`inputItem coreItem_${i}`} style={{width: parseInt(taskCount / 8000 * 100 , 10) + '%' }}>
+                <div className={`inputItem coreItem_${i}`} style={{width: taskWidth + '%' }}>
                 </div>
                 <span>{taskCount && taskCount}</span>
               </section>

--- a/src/containers/simulator/simulatorContainer.js
+++ b/src/containers/simulator/simulatorContainer.js
@@ -46,6 +46,7 @@ const SimulatorContainer = ({
   <div id="simulatorContainer">
     <CoreInput
       parseResults={parseResults}
+      runProgress={runProgress}
       removeWarrior={removeWarrior} />
     <SimulatorControls
       isInitialised={isInitialised}

--- a/src/reducers/simulatorReducers.js
+++ b/src/reducers/simulatorReducers.js
@@ -45,7 +45,8 @@ export default (state = initialState, action) => {
       return {
         ...state,
         isInitialised: true,
-        roundResult: {}
+        roundResult: {},
+        runProgress: 0
       }
 
     case STEP:


### PR DESCRIPTION
Resolves #124 by resetting `runProgress` on `init`.

Resets the local component state of `coreInput` in response to `runProgress === 0`