### PR TITLE
Make parser errors dismissable

### DIFF
--- a/src/features/app/appContainer.js
+++ b/src/features/app/appContainer.js
@@ -16,7 +16,9 @@ import { space } from '../common/theme'
 
 import {
   parse,
-  addWarrior
+  addWarrior,
+  hideMessages,
+  showMessages
 } from '../parser/actions'
 
 import {
@@ -41,18 +43,18 @@ const ParserGrid = styled.section`
   height: calc(100vh - ${space.header} - ${space.header});
 `
 
-const CompleteInterface = ({ redcode, parse, currentParseResult,
+const AppContainer = ({ redcode, parse, currentParseResult,
   coreSize, getCoreInstructions, isRunning, isInitialised, addWarrior,
-  run, pause, step, init }) => (
+  run, pause, step, init, hideMessages, showMessages, displayMessages }) => (
   <DesktopContainer>
     <Controls>
       <Button onClick={addWarrior} enabled={hasNoErrors(currentParseResult)}>
         <Octicon mega name="chevron-right"/>
       </Button>
       <ParseStatusButton
-        enabled={hasNoErrors(currentParseResult)}
+        enabled={true}
         messages={currentParseResult.messages}
-        handleClick={() => { console.log('disabled clicked me') }}>
+        handleClick={showMessages}>
           <Octicon mega name="issue-opened"/>
       </ParseStatusButton>
     </Controls>
@@ -63,20 +65,23 @@ const CompleteInterface = ({ redcode, parse, currentParseResult,
       <CompiledOutput desktop>
         {currentParseResult.warrior}
       </CompiledOutput>
-      <MessagePanel messages={currentParseResult.messages} />
+      <MessagePanel
+        messages={currentParseResult.messages}
+        hideMessages={hideMessages}
+        show={displayMessages}
+        />
     </ParserGrid>
     <Instructions />
-
-      <SimulatorContainer
-        coreSize={coreSize}
-        getCoreInstructions={getCoreInstructions}
-        isRunning={isRunning}
-        isInitialised={isInitialised}
-        run={run}
-        pause={pause}
-        step={step}
-        init={init}
-        />
+    <SimulatorContainer
+      coreSize={coreSize}
+      getCoreInstructions={getCoreInstructions}
+      isRunning={isRunning}
+      isInitialised={isInitialised}
+      run={run}
+      pause={pause}
+      step={step}
+      init={init}
+      />
 
   </DesktopContainer>
 )
@@ -91,7 +96,8 @@ const mapStateToProps = state => ({
   coreSize: state.simulator.coreSize,
   getCoreInstructions: state.simulator.getCoreInstructions,
   isRunning: state.simulator.isRunning,
-  isInitialised: state.simulator.isInitialised
+  isInitialised: state.simulator.isInitialised,
+  displayMessages: state.parser.displayMessages
 })
 
 export default connect(
@@ -103,8 +109,10 @@ export default connect(
     parse,
     step,
     addWarrior,
-    getCoreInstructions
+    getCoreInstructions,
+    hideMessages,
+    showMessages
   }
-)(CompleteInterface)
+)(AppContainer)
 
-export { CompleteInterface as PureCompleteInterface }
+export { AppContainer as PureAppContainer }

--- a/src/features/app/appContainer.js
+++ b/src/features/app/appContainer.js
@@ -48,7 +48,7 @@ const AppContainer = ({ redcode, parse, currentParseResult,
   run, pause, step, init, hideMessages, showMessages, displayMessages }) => (
   <DesktopContainer>
     <Controls>
-      <Button onClick={addWarrior} enabled={hasNoErrors(currentParseResult)}>
+      <Button handleClick={addWarrior} enabled={hasNoErrors(currentParseResult)}>
         <Octicon mega name="chevron-right"/>
       </Button>
       <ParseStatusButton

--- a/src/features/app/mobileLayout.js
+++ b/src/features/app/mobileLayout.js
@@ -8,7 +8,7 @@ import InputContainer from '../parser/inputContainer'
 import OutputContainer from '../parser/outputContainer'
 import SimulatorContainer from '../simulator/simulatorContainer'
 
-import { colour, space } from '../common/theme'
+import { space } from '../common/theme'
 
 const MobileGrid = styled.div`
   display: grid;

--- a/src/features/common/button.js
+++ b/src/features/common/button.js
@@ -18,8 +18,8 @@ const Button = styled.button.attrs({
   }
 `
 
-// Button.propTypes = {
-//   handleClick: PropTypes.func.required
-// }
+Button.propTypes = {
+  handleClick: PropTypes.func.required
+}
 
 export default Button

--- a/src/features/parser/actions.js
+++ b/src/features/parser/actions.js
@@ -3,6 +3,8 @@ import { action } from '../../actions/creator'
 export const PARSE = 'parser/PARSE'
 export const ADD_WARRIOR = 'parser/ADD_WARRIOR'
 export const REMOVE_WARRIOR = 'parser/REMOVE_WARRIOR'
+export const SHOW_MESSAGES = 'parser/SHOW_MESSAGES'
+export const HIDE_MESSAGES = 'parser/HIDE_MESSAGES'
 
 export const PARSE_REQUESTED = 'parser/PARSE_REQUESTED'
 export const ADD_WARRIOR_REQUESTED = 'parser/ADD_WARRIOR_REQUESTED'
@@ -11,3 +13,5 @@ export const REMOVE_WARRIOR_REQUESTED = 'parser/REMOVE_WARRIOR_REQUESTED'
 export const parse = redcode => action(PARSE_REQUESTED, { redcode })
 export const addWarrior = () => action(ADD_WARRIOR_REQUESTED)
 export const removeWarrior = index => action(REMOVE_WARRIOR_REQUESTED, { index })
+export const showMessages = () => action(SHOW_MESSAGES)
+export const hideMessages = () => action(HIDE_MESSAGES)

--- a/src/features/parser/combinedContainer.js
+++ b/src/features/parser/combinedContainer.js
@@ -11,7 +11,8 @@ import ControlsContainer from '../parser/controlsContainer'
 import { space } from '../common/theme'
 
 import {
-  parse
+  parse,
+  hideMessages
 } from './actions'
 
 const ParserGrid = styled.section`
@@ -19,7 +20,7 @@ const ParserGrid = styled.section`
   height: calc(100vh - ${space.header} - ${space.controls});
 `
 
-const ParserInterface = ({ redcode, parse, currentParseResult, addWarrior }) => (
+const ParserInterface = ({ redcode, parse, currentParseResult, addWarrior, hideMessages, displayMessages }) => (
   <MobilePage tablet>
     <ParserGrid>
       <SourceCodeTextArea
@@ -30,19 +31,25 @@ const ParserInterface = ({ redcode, parse, currentParseResult, addWarrior }) => 
       </CompiledOutput>
     </ParserGrid>
     <ControlsContainer />
-    <MessagePanel messages={currentParseResult.messages} />
+    <MessagePanel
+      messages={currentParseResult.messages}
+      hideMessages={hideMessages}
+      show={displayMessages} />
   </MobilePage>
 )
 
+
 const mapStateToProps = state => ({
   redcode: state.parser.redcode,
-  currentParseResult: state.parser.currentParseResult
+  currentParseResult: state.parser.currentParseResult,
+  displayMessages: state.parser.displayMessages
 })
 
 export default connect(
   mapStateToProps,
   {
-    parse
+    parse,
+    hideMessages
   }
 )(ParserInterface)
 

--- a/src/features/parser/controlsContainer.js
+++ b/src/features/parser/controlsContainer.js
@@ -8,15 +8,16 @@ import Controls from  '../common/controls'
 import ParseStatusButton from  './parseStatusButton'
 
 import {
-  addWarrior
+  addWarrior,
+  showMessages
 } from './actions'
 
-const MobileControls = ({ addWarrior, currentParseResult }) => (
+const MobileControls = ({ addWarrior, currentParseResult, showMessages }) => (
   <Controls>
     <ParseStatusButton
-      enabled={hasNoErrors(currentParseResult)}
+      enabled={true}
       messages={currentParseResult.messages}
-      handleClick={() => { console.log('disabled clicked me') }}>
+      handleClick={showMessages}>
       <Octicon mega name="issue-opened"/>
     </ParseStatusButton>
     <Button
@@ -46,7 +47,8 @@ const mapStateToProps = state => ({
 export default connect(
   mapStateToProps,
   {
-    addWarrior
+    addWarrior,
+    showMessages
   }
 )(MobileControls)
 

--- a/src/features/parser/inputContainer.js
+++ b/src/features/parser/inputContainer.js
@@ -7,28 +7,34 @@ import MessagePanel from './messagePanel'
 import ControlsContainer from '../parser/controlsContainer'
 
 import {
-  parse
+  parse,
+  hideMessages
 } from './actions'
 
-const InputContainer = ({ redcode, parse, currentParseResult }) => (
+const InputContainer = ({ redcode, parse, currentParseResult, hideMessages, displayMessages }) => (
   <MobilePage mobile>
     <SourceCodeTextArea
       value={redcode}
       handleChange={e => parse(e.target.value)} />
     <ControlsContainer />
-    <MessagePanel messages={currentParseResult && currentParseResult.messages} />
+    <MessagePanel
+      hideMessages={hideMessages}
+      messages={currentParseResult && currentParseResult.messages}
+      show={displayMessages} />
   </MobilePage>
 )
 
 const mapStateToProps = state => ({
   redcode: state.parser.redcode,
-  currentParseResult: state.parser.currentParseResult
+  currentParseResult: state.parser.currentParseResult,
+  displayMessages: state.parser.displayMessages
 })
 
 export default connect(
   mapStateToProps,
   {
-    parse
+    parse,
+    hideMessages
   }
 )(InputContainer)
 

--- a/src/features/parser/messagePanel.js
+++ b/src/features/parser/messagePanel.js
@@ -1,14 +1,18 @@
 import React from 'react'
 import styled from 'styled-components'
+import FontAwesome from 'react-fontawesome'
 
 import { colour, space, font } from '../common/theme'
 import { media } from '../common/mediaQuery'
+import FontAwesomeButton from '../simulator/fontAwesomeButton'
 
 const ParseMessageWrapper = styled.div`
-  ${props => props.messages && props.messages.length > 0 ? `display: block;` : `display: none;`}
+  ${props =>  props.show ? `display: block;` : `display: none;`}
   position: absolute;
   bottom: 0;
   min-height: 100px;
+  max-height: 40%;
+  overflow-y: hidden;
   height: auto;
   width: calc(50% - 5px);
   border-right: 1px solid ${colour.grey};
@@ -37,9 +41,21 @@ const ColouredMessageText = styled.span`
  ${props => props.type === 2 && `color: ${colour.info};`}
 `
 
-const MessagePanel = ({ messages }) => (
+const CloseButton = styled.div`
+  position: absolute;
+  right: ${space.s};
+  top: ${space.s};
+  &:hover {
+    cursor: pointer;
+  }
+`
 
-  <ParseMessageWrapper messages={messages}>
+const MessagePanel = ({ messages, hideMessages, show }) => (
+
+  <ParseMessageWrapper messages={messages} show={show} onClick={hideMessages}>
+    <CloseButton>
+      <FontAwesome name={`times`} />
+    </CloseButton>
     <MessageRow>
       <span>line</span>
       <span>char</span>

--- a/src/features/parser/messagePanel.js
+++ b/src/features/parser/messagePanel.js
@@ -4,7 +4,6 @@ import FontAwesome from 'react-fontawesome'
 
 import { colour, space, font } from '../common/theme'
 import { media } from '../common/mediaQuery'
-import FontAwesomeButton from '../simulator/fontAwesomeButton'
 
 const ParseMessageWrapper = styled.div`
   ${props =>  props.show ? `display: block;` : `display: none;`}

--- a/src/features/parser/reducer.js
+++ b/src/features/parser/reducer.js
@@ -2,7 +2,6 @@ import {
   PARSE,
   ADD_WARRIOR,
   REMOVE_WARRIOR,
-  TOGGLE_MESSAGES,
   SHOW_MESSAGES,
   HIDE_MESSAGES
 } from './actions'
@@ -46,7 +45,6 @@ export default (state = initialState, action) => {
       }
 
     case SHOW_MESSAGES:
-      console.log('show')
       return {
         ...state,
         displayMessages: true

--- a/src/features/parser/reducer.js
+++ b/src/features/parser/reducer.js
@@ -1,7 +1,10 @@
 import {
   PARSE,
   ADD_WARRIOR,
-  REMOVE_WARRIOR
+  REMOVE_WARRIOR,
+  TOGGLE_MESSAGES,
+  SHOW_MESSAGES,
+  HIDE_MESSAGES
 } from './actions'
 
 // state
@@ -11,7 +14,8 @@ const initialState = {
   parseResults: [],
   standardId: 2, // TODO: what's the best standard to use as a default?
   redcode: '',
-  warrior: ''
+  warrior: '',
+  displayMessages: false
 }
 
 // selectors
@@ -39,6 +43,19 @@ export default (state = initialState, action) => {
       return {
         ...state,
         parseResults: action.result
+      }
+
+    case SHOW_MESSAGES:
+      console.log('show')
+      return {
+        ...state,
+        displayMessages: true
+      }
+
+    case HIDE_MESSAGES:
+      return {
+        ...state,
+        displayMessages: false
       }
 
     default:

--- a/src/features/parser/sagas.js
+++ b/src/features/parser/sagas.js
@@ -9,7 +9,8 @@ import {
   ADD_WARRIOR,
   ADD_WARRIOR_REQUESTED,
   REMOVE_WARRIOR,
-  REMOVE_WARRIOR_REQUESTED
+  REMOVE_WARRIOR_REQUESTED,
+  SHOW_MESSAGES
 } from './actions'
 
 import { getParserState } from './reducer'
@@ -24,13 +25,15 @@ export function* parseSaga({ redcode }) {
 
   result.warrior = warrior;
 
+  if(result.messages.find(x => x.type === 0)){
+    yield put({ type: SHOW_MESSAGES })
+  }
+
   yield put({ type: PARSE, result, redcode })
 
 }
 
 export function* addWarriorSaga() {
-
-  console.log('add warrior')
 
   yield call(pauseSaga)
 


### PR DESCRIPTION
Fixes #177 by allowing the parser errors to be shown by clicking on the info icon.

They can then be dismissed by clicking on the error panel again or a cross / close icon in the top right

![image](https://user-images.githubusercontent.com/1190042/36076530-2a365b14-0f55-11e8-8b14-e1613657abdf.png)
