### PR TITLE
Rework simulator buttons

### DIFF
--- a/src/features/common/controls.js
+++ b/src/features/common/controls.js
@@ -8,22 +8,26 @@ const Controls = styled.div`
   border: none;
   padding-left: 1em;
   padding-right: 1em;
+  background-color: ${colour.defaultbg};
+  // border-top: 1px solid ${colour.grey};
+  // border-left: 1px solid ${colour.grey};
+  // border-right: 1px solid ${colour.grey};
 
   ${media.phone`
     border-top: 1px solid ${colour.grey};
-    background-color: ${colour.lightbg};
+
   `}
   ${media.tablet`
     border-top: 1px solid ${colour.grey};
-    background-color: ${colour.lightbg};
+
   `}
   ${media.desktop`
     border-top: 1px solid ${colour.grey};
-    background-color: ${colour.lightbg};
   `}
 
   display: flex;
   flex-direction: row;
+  justify-content: space-around;
   height: calc(${space.controls} - 1px);
 `
 

--- a/src/features/common/controls.js
+++ b/src/features/common/controls.js
@@ -14,15 +14,15 @@ const Controls = styled.div`
   // border-right: 1px solid ${colour.grey};
 
   ${media.phone`
-    border-top: 1px solid ${colour.grey};
+    border-top: 1px solid ${colour.lightbg};
 
   `}
   ${media.tablet`
-    border-top: 1px solid ${colour.grey};
+    border-top: 1px solid ${colour.lightbg};
 
   `}
   ${media.desktop`
-    border-top: 1px solid ${colour.grey};
+    border-top: 1px solid ${colour.lightbg};
   `}
 
   display: flex;

--- a/src/features/common/featureButton.js
+++ b/src/features/common/featureButton.js
@@ -1,6 +1,6 @@
 import styled from 'styled-components'
 
-import { colour, font, space } from '../common/theme'
+import { colour, space } from '../common/theme'
 
 const FeatureButton = styled.a`
   border: 2px solid ${colour.white};

--- a/src/features/common/heroLogo.js
+++ b/src/features/common/heroLogo.js
@@ -2,8 +2,6 @@ import React from 'react'
 import styled from 'styled-components'
 import Octicon from 'react-octicon'
 
-import FeatureButton from '../common/featureButton'
-
 import { colour, space, font } from '../common/theme'
 import { media } from '../common/mediaQuery'
 
@@ -37,13 +35,6 @@ const Logo = styled.div`
   flex-direction: row;
   justify-content: center;
   align-items: center;
-`
-
-const PrimaryButton = FeatureButton.extend`
-  background: ${colour.white};
-  color: ${colour.darkbg};
-  transition: 0.2s;
-  font-weight: bold;
 `
 
 const Features = styled.section`

--- a/src/features/common/siteNav.js
+++ b/src/features/common/siteNav.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import styled from 'styled-components'
 
-import { colour, font, space } from '../common/theme'
+import { colour, space } from '../common/theme'
 import { media } from '../common/mediaQuery'
 
 const Header = styled.header`

--- a/src/features/navbar/navbar.js
+++ b/src/features/navbar/navbar.js
@@ -11,7 +11,7 @@ const NavBarGrid = styled.div`
 
 const NavBar = () => (
   <NavBarGrid>
-    <TabLink to='/app/src'>src</TabLink>
+    <TabLink to='/app/src'>source</TabLink>
     <TabLink to='/app/output'>output</TabLink>
     <TabLink to='/app/core'>core</TabLink>
   </NavBarGrid>

--- a/src/features/onboarding/home.js
+++ b/src/features/onboarding/home.js
@@ -398,12 +398,12 @@ const Home = () => (
         warriors.
       </FeatureDescription>
       <FeatureImageWrapper>
-        <img src={SimulatorImage} />
+        <img src={SimulatorImage} alt={`Animated core simulator example`} />
       </FeatureImageWrapper>
     </Simulator>
     <Parser>
       <FeatureImageWrapper>
-        <img src={ParserImage} />
+        <img src={ParserImage} alt={`Animated parser usage example`} />
       </FeatureImageWrapper>
       <FeatureDescription>
         Write and parse your warriors in our online editor and receive realtime feedback on parser errors.

--- a/src/features/parser/compiledOutput.js
+++ b/src/features/parser/compiledOutput.js
@@ -5,7 +5,7 @@ import { colour, space } from '../common/theme'
 
 const CompiledOutput = styled.pre`
   ${sourceCode};
-  border-left: ${props => !props.mobile && `1px solid ${colour.grey}`};
+  border-left: ${props => !props.mobile && `1px solid ${colour.lightbg}`};
   width: ${props => !props.mobile && `40%`};
   height: ${props => props.desktop && `calc(100vh - ${space.m} - ${space.m} - ${space.header} - ${space.header})`};
   color: ${colour.blue};

--- a/src/features/signup/sagas.js
+++ b/src/features/signup/sagas.js
@@ -1,4 +1,3 @@
-import { delay } from 'redux-saga'
 import { takeEvery, call, put } from 'redux-saga/effects'
 import $ from 'jquery'
 

--- a/src/features/simulator/controlsContainer.js
+++ b/src/features/simulator/controlsContainer.js
@@ -17,7 +17,7 @@ const SimulatorControls = ({ isRunning, isInitialised, run, pause, step, init, p
   <Controls>
     <FontAwesomeButton visible={!isRunning} enabled={isInitialised} iconName="play" handleClick={run} />
     <FontAwesomeButton visible={isRunning} enabled={isRunning} iconName="pause" handleClick={pause} />
-    <FontAwesomeButton visible={true} enabled={!isRunning} iconName="step-forward" handleClick={step} />
+    <FontAwesomeButton visible={true} enabled={isInitialised && !isRunning} iconName="step-forward" handleClick={step} />
     <FontAwesomeButton visible={true} enabled={true} iconName="undo" handleClick={init} />
     <SpeedControl visible={true} enabled={true} handleClick={setProcessRate} processRate={processRate} processRates={processRates} />
   </Controls>

--- a/src/features/simulator/core.js
+++ b/src/features/simulator/core.js
@@ -20,7 +20,7 @@ const CanvasWrapper = styled.section`
   ${media.tablet`min-width: 400px;`}
   ${media.phone`min-width: 400px;`}
 
-  border: 1px solid ${colour.lightbg};
+  // border: 1px solid ${colour.lightbg};
 
   canvas {
     position: absolute;

--- a/src/features/simulator/fontAwesomeButton.js
+++ b/src/features/simulator/fontAwesomeButton.js
@@ -7,22 +7,46 @@ import { colour, font } from '../common/theme'
 const Container = styled.div.attrs({
   onClick: props => props.enabled ? props.handleClick : null
 })`
+
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   ${props => !props.visible && `display: none;`}
-  ${props => props.enabled ? `color: ${colour.white};` : `color: ${colour.grey};`}
-  font-size: ${font.small};
-  width: 100%;
-  text-align: center;
-  margin-top: ${font.small};
+  ${props => props.enabled ? `color: ${colour.lightgrey};` : `color: ${colour.grey};`}
+  font-size: ${font.base};
+
+  i.fa.fa-stack-1x {
+    ${props => props.enabled ? `color: ${colour.lightgrey};` : `color: ${colour.grey};`}
+  }
+
+  i.fa.fa-stack-2x {
+    color: transparent;
+    box-shadow: 0 0 2px ${colour.lightgrey};
+    border-radius: 50%;
+  }
 
   &:hover {
     cursor: ${props => props.enabled && `pointer`};
     color: ${props => props.enabled && `${colour.blue}`};
+
+    i.fa.fa-stack-1x {
+      color: ${props => props.enabled && `${colour.defaultbg}`};
+    }
+
+    i.fa.fa-stack-2x {
+      color: ${props => props.enabled && `${colour.white}`};
+    }
   }
+
 `
 
 const FontAwesomeButton = ({ visible, enabled, handleClick, iconName }) => (
   <Container visible={visible} enabled={enabled} handleClick={handleClick}>
-    <FontAwesome name={iconName} size="2x" />
+    <span class="fa-stack">
+      <i class="fa fa-circle fa-stack-2x"></i>
+      <i class={`fa fa-${iconName} fa-stack-1x fa-inverse`}></i>
+    </span>
   </Container>
 )
 

--- a/src/features/simulator/fontAwesomeButton.js
+++ b/src/features/simulator/fontAwesomeButton.js
@@ -1,8 +1,7 @@
 import React from 'react'
-import FontAwesome from 'react-fontawesome'
 import styled from 'styled-components'
 
-import { colour, font } from '../common/theme'
+import { colour } from '../common/theme'
 
 const Container = styled.div.attrs({
   onClick: props => props.enabled ? props.handleClick : null

--- a/src/features/simulator/fontAwesomeButton.js
+++ b/src/features/simulator/fontAwesomeButton.js
@@ -14,38 +14,51 @@ const Container = styled.div.attrs({
   justify-content: center;
   ${props => !props.visible && `display: none;`}
   ${props => props.enabled ? `color: ${colour.lightgrey};` : `color: ${colour.grey};`}
-  font-size: ${font.base};
+  font-size: 20px;
 
-  i.fa.fa-stack-1x {
-    ${props => props.enabled ? `color: ${colour.lightgrey};` : `color: ${colour.grey};`}
-  }
 
-  i.fa.fa-stack-2x {
-    color: transparent;
-    box-shadow: 0 0 2px ${colour.lightgrey};
+  span {
+    border: 1px solid ${colour.coral};
+    width: 2em;
+    height: 2em;
     border-radius: 50%;
   }
 
+  i {
+    color: ${colour.grey};
+    margin: 0.5em 0 0 0.5em;
+  }
+
+  .fa-play {
+    padding-left: 0.15em;
+  }
+
+  .fa-step-forward {
+    padding-left: 0.2em;
+  }
+
+  .fa-undo {
+    padding-left: 0.05em;
+  }
+
   &:hover {
-    cursor: ${props => props.enabled && `pointer`};
-    color: ${props => props.enabled && `${colour.blue}`};
-
-    i.fa.fa-stack-1x {
-      color: ${props => props.enabled && `${colour.defaultbg}`};
-    }
-
-    i.fa.fa-stack-2x {
-      color: ${props => props.enabled && `${colour.white}`};
-    }
+    ${props => props.enabled && `
+      cursor: pointer;
+      span {
+        background-color: ${colour.coral};
+      }
+      i {
+        color: ${colour.white};
+      }
+    `}
   }
 
 `
 
 const FontAwesomeButton = ({ visible, enabled, handleClick, iconName }) => (
   <Container visible={visible} enabled={enabled} handleClick={handleClick}>
-    <span class="fa-stack">
-      <i class="fa fa-circle fa-stack-2x"></i>
-      <i class={`fa fa-${iconName} fa-stack-1x fa-inverse`}></i>
+    <span>
+      <i className={`fa fa-${iconName}`}></i>
     </span>
   </Container>
 )

--- a/src/features/simulator/instructions.js
+++ b/src/features/simulator/instructions.js
@@ -8,9 +8,8 @@ import { colour } from '../common/theme'
 
 const InstructionWrapper = styled.section`
   display: grid;
-  border-left: 1px solid ${colour.grey};
-  border-right: 1px solid ${colour.grey};
-
+  border-left: 1px solid ${colour.lightbg};
+  border-right: 1px solid ${colour.lightbg};
 `
 
 const CoreVisuliser = ({ instructions }) => (

--- a/src/features/simulator/sagas.js
+++ b/src/features/simulator/sagas.js
@@ -140,9 +140,13 @@ export function* initialiseCore(options, warriors) {
 
   yield call(PubSub.publishSync, 'RESET_CORE')
 
-  yield call([corewar, corewar.initialiseSimulator], options, warriors, PubSub)
+  if(warriors.length > 0) {
 
-  yield put({ type: INIT })
+    yield call([corewar, corewar.initialiseSimulator], options, warriors, PubSub)
+
+    yield put({ type: INIT })
+
+  }
 
 }
 

--- a/src/features/simulator/speedControl.js
+++ b/src/features/simulator/speedControl.js
@@ -7,7 +7,7 @@ const Container = styled.div`
   ${props => !props.visible && `display: none;`};
   color: ${props => props.enabled ? `${colour.white}` : `${colour.grey}`};
   font-size: ${font.small};
-  width: 100%;
+  flex: 1;
   text-align: center;
   position: relative;
   height: 100%;

--- a/src/features/simulator/warriors.js
+++ b/src/features/simulator/warriors.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react'
 import styled from 'styled-components'
-import { List } from 'immutable'
 import * as PubSub from 'pubsub-js'
 import Octicon from 'react-octicon'
 

--- a/src/features/topbar/siteHeader.js
+++ b/src/features/topbar/siteHeader.js
@@ -33,7 +33,7 @@ const SiteHeader = ({ isAuthenticated }) => (
   <Header>
     <Logo siteName='corewar' siteDomain='.io' />
     <Nav>
-      <TabLink to='/app/src'>src</TabLink>
+      <TabLink to='/app/src'>source</TabLink>
       <TabLink to='/app/core'>core</TabLink>
     </Nav>
     {isAuthenticated ? <UserInfo /> : <Login />}

--- a/src/features/tutorial/tutorialContainer.js
+++ b/src/features/tutorial/tutorialContainer.js
@@ -7,7 +7,6 @@ import { media } from '../common/mediaQuery'
 
 import SiteNav from '../common/siteNav'
 import HeroLogo from '../common/heroLogo'
-import FeatureButton from '../common/featureButton'
 
 import {
   moveImp


### PR DESCRIPTION
Reworks the simulator buttons they are a bit more buttony and obvious. Fixes #199 

![image](https://user-images.githubusercontent.com/1190042/36932913-956af1a6-1ec8-11e8-99b0-09202364fcbe.png)


Removed the button bar and made page break lines more subtle.

Fixed bug where step button was enabled before warriors were added.
Fixed bug where reset / init button would init with no warriors, making `play` and `step` available, which could crash the app.