### PR TITLE
Add `file tabs` to manage warriors and remove them from simulator layout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,14 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@sinonjs/formatio": {
+      "version": "2.0.0",
+      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "requires": {
+        "samsam": "1.3.0"
+      }
+    },
     "@types/clone": {
       "version": "0.1.30",
       "resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
@@ -15,9 +23,9 @@
       "integrity": "sha512-LooLR6XHes9V+kNYRz1Qm8w3atw9QMn7XeZUmIpUelllF9BdryeUKd/u0Wh5ErcjpWfG39NrToU9MF7ngsTFVw=="
     },
     "@types/node": {
-      "version": "8.0.53",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.53.tgz",
-      "integrity": "sha512-54Dm6NwYeiSQmRB1BLXKr5GELi0wFapR1npi8bnZhEcu84d/yQKqnwwXQ56hZ0RUbTG6L5nqDZaN3dgByQXQRQ==",
+      "version": "9.4.7",
+      "resolved": "http://registry.npmjs.org/@types/node/-/node-9.4.7.tgz",
+      "integrity": "sha512-4Ba90mWNx8ddbafuyGGwjkZMigi+AWfYLSDCpovwsE63ia8w93r3oJ8PIAQc3y8U+XHcnMOHPIzNe3o438Ywcw==",
       "dev": true
     },
     "abab": {
@@ -1043,6 +1051,28 @@
         "babel-types": "6.26.0"
       }
     },
+    "babel-polyfill": {
+      "version": "6.23.0",
+      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
+      "integrity": "sha1-g2TKYt+Or7gwSZ9pkXdGbDsDSZ0=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.10.5"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
+          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
+        }
+      }
+    },
     "babel-preset-env": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.6.1.tgz",
@@ -1693,7 +1723,7 @@
           "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
           "dev": true,
           "requires": {
-            "@types/node": "8.0.53"
+            "@types/node": "9.4.7"
           }
         }
       }
@@ -2050,7 +2080,7 @@
         "clone": "2.1.1",
         "core-js": "2.5.3",
         "npm-cli-login": "0.0.10",
-        "pubsub-js": "1.5.7",
+        "pubsub-js": "1.6.0",
         "user": "0.0.0"
       },
       "dependencies": {
@@ -2316,9 +2346,9 @@
       }
     },
     "css-to-react-native": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.0.4.tgz",
-      "integrity": "sha1-z0zEB1WLNHTUuovhos07bOcTEBs=",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/css-to-react-native/-/css-to-react-native-2.1.2.tgz",
+      "integrity": "sha512-akxvxNPNm+Qb7kGswgWhD8rLENM8857NVIn1lX0Dr9BQuju8vx6ypet7KvwvqBC01FUEne5V/jvt7FJXWJPtgw==",
       "requires": {
         "css-color-keywords": "1.0.0",
         "fbjs": "0.8.16",
@@ -2842,18 +2872,23 @@
       "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "enzyme": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.2.0.tgz",
-      "integrity": "sha512-l0HcjycivXjB4IXkwuRc1K5z8hzWIVZB2b/Y/H2bao9eFTpBz4ACOwAQf44SgG5Nu3d1jF41LasxDgFWZeeysA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.3.0.tgz",
+      "integrity": "sha512-l8csyPyLmtxskTz6pX9W8eDOyH1ckEtDttXk/vlFWCjv00SkjTjtoUrogqp4yEvMyneU9dUJoOLnqFoiHb8IHA==",
       "dev": true,
       "requires": {
         "cheerio": "1.0.0-rc.2",
-        "function.prototype.name": "1.0.3",
+        "function.prototype.name": "1.1.0",
         "has": "1.0.1",
+        "is-boolean-object": "1.0.0",
+        "is-callable": "1.1.3",
+        "is-number-object": "1.0.3",
+        "is-string": "1.0.4",
         "is-subset": "0.1.1",
         "lodash": "4.17.4",
+        "object-inspect": "1.5.0",
         "object-is": "1.0.1",
-        "object.assign": "4.0.4",
+        "object.assign": "4.1.0",
         "object.entries": "1.0.4",
         "object.values": "1.0.4",
         "raf": "3.4.0",
@@ -2861,34 +2896,35 @@
       }
     },
     "enzyme-adapter-react-16": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.0.tgz",
-      "integrity": "sha512-OlZJn5PJUJ91EOQQRuISZpXgPlqT9fYR2yBZQPu9UYok+wS19Rn4teXywF34LMcyw2AzE1s0ZRDtcI952/vQHg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz",
+      "integrity": "sha512-kC8pAtU2Jk3OJ0EG8Y2813dg9Ol0TXi7UNxHzHiWs30Jo/hj7alc//G1YpKUsPP1oKl9X+Lkx+WlGJpPYA+nvw==",
       "dev": true,
       "requires": {
-        "enzyme-adapter-utils": "1.2.0",
+        "enzyme-adapter-utils": "1.3.0",
         "lodash": "4.17.4",
-        "object.assign": "4.0.4",
+        "object.assign": "4.1.0",
         "object.values": "1.0.4",
-        "prop-types": "15.6.0",
-        "react-test-renderer": "16.1.1"
+        "prop-types": "15.6.1",
+        "react-reconciler": "0.7.0",
+        "react-test-renderer": "16.2.0"
       }
     },
     "enzyme-adapter-utils": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.2.0.tgz",
-      "integrity": "sha512-6CeIrmymLWoQgvH5m/ixJLaCsa6pSoWU2nlMeO0nHCZR8LQ+tKzP/jPh4qceTPlB4oFfyMRFeqr0+IryY4gAxg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz",
+      "integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
       "dev": true,
       "requires": {
         "lodash": "4.17.4",
-        "object.assign": "4.0.4",
-        "prop-types": "15.6.0"
+        "object.assign": "4.1.0",
+        "prop-types": "15.6.1"
       }
     },
     "enzyme-to-json": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.3.1.tgz",
-      "integrity": "sha512-PrgRyZAgEwOrh5/8BtBWrwGcv1mC7yNohytIciAX6SUqDaXg1BlU8CepYQ9BgnDP1i1jTB65qJJITMMCph+T6A==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.3.3.tgz",
+      "integrity": "sha1-7eRZOPswnNh+vUOG9gx1RSVRWgc=",
       "requires": {
         "lodash": "4.17.4"
       }
@@ -3305,7 +3341,7 @@
         "doctrine": "2.0.0",
         "has": "1.0.1",
         "jsx-ast-utils": "2.0.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       },
       "dependencies": {
         "jsx-ast-utils": {
@@ -3824,14 +3860,6 @@
         "mime-types": "2.1.17"
       }
     },
-    "formatio": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
-      "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
-      "requires": {
-        "samsam": "1.3.0"
-      }
-    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -4237,7 +4265,8 @@
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
@@ -4651,9 +4680,9 @@
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "function.prototype.name": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.3.tgz",
-      "integrity": "sha512-5EblxZUdioXi2JiMZ9FUbwYj40eQ9MFHyzFLBSPdlRl3SO8l7SLWuAnQ/at/1Wi4hjJwME/C5WpF2ZfAc8nGNw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.1.0.tgz",
+      "integrity": "sha512-Bs0VRrTz4ghD8pTmbJQD1mZ8A/mN0ur/jGz+A6FBxPDUPkm1tNfF6bhTYPA7i7aF4lZJVr+OXTNNrnnIl58Wfg==",
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
@@ -4913,6 +4942,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
       "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE="
+    },
+    "has-symbols": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -5395,6 +5430,12 @@
         "binary-extensions": "1.11.0"
       }
     },
+    "is-boolean-object": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.0.tgz",
+      "integrity": "sha1-mPiygDBoQhmpXzdc+9iM40Bd/5M=",
+      "dev": true
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -5493,6 +5534,12 @@
         "kind-of": "3.2.2"
       }
     },
+    "is-number-object": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.3.tgz",
+      "integrity": "sha1-8mWrian0RQNO9q/xWo8AsA9VF5k=",
+      "dev": true
+    },
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
@@ -5589,6 +5636,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+    },
+    "is-string": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.4.tgz",
+      "integrity": "sha1-zDqbaYV9Yh6WNyWiTK7shzuCbmQ=",
+      "dev": true
     },
     "is-subset": {
       "version": "0.1.1",
@@ -7384,9 +7437,9 @@
       "integrity": "sha1-rgyqVhERSYxboTcj1vtjHSQAOTQ="
     },
     "lolex": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.1.tgz",
-      "integrity": "sha512-mQuW55GhduF3ppo+ZRUTz1PRjEh1hS5BbqU7d8D0ez2OKxHDod7StPPeAVKisZR5aLkHZjdGWSL42LSONUJsZw=="
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng=="
     },
     "longest": {
       "version": "1.0.1",
@@ -7690,22 +7743,15 @@
       "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "nise": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.0.tgz",
-      "integrity": "sha512-q9jXh3UNsMV28KeqI43ILz5+c3l+RiNW8mhurEwCKckuHQbL+hTJIKKTiUlCPKlgQ/OukFvSnKB/Jk3+sFbkGA==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.3.1.tgz",
+      "integrity": "sha512-kIH3X5YCj1vvj/32zDa9KNgzvfZd51ItGbiaCbtYhpnsCedLo0tIkb9zl169a41ATzF4z7kwMLz35XXDypma3g==",
       "requires": {
-        "formatio": "1.2.0",
+        "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
-        "lolex": "1.6.0",
+        "lolex": "2.3.2",
         "path-to-regexp": "1.7.0",
         "text-encoding": "0.6.4"
-      },
-      "dependencies": {
-        "lolex": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
-          "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY="
-        }
       }
     },
     "no-case": {
@@ -7932,9 +7978,9 @@
       "integrity": "sha512-smRWXzkvxw72VquyZ0wggySl7PFUtoDhvhpdwgESXxUrH7vVhhp9asfup1+rVLrhsl7L45Ee1Q/l5R2Ul4MwUg=="
     },
     "object-inspect": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.3.0.tgz",
-      "integrity": "sha512-OHHnLgLNXpM++GnJRyyhbr2bwl3pPVm4YvaraHrRvDt/N3r+s/gDVHciA7EJBTkijKXj61ssgSAikq1fb0IBRg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.5.0.tgz",
+      "integrity": "sha512-UmOFbHbwvv+XHj7BerrhVq+knjceBdkvU5AriwLMvhv2qi+e7DJzxfBeFpILEjVzCp+xA+W/pIf06RGPWlZNfw=="
     },
     "object-is": {
       "version": "1.0.1",
@@ -7948,13 +7994,14 @@
       "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
     },
     "object.assign": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
-      "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
         "define-properties": "1.1.2",
         "function-bind": "1.1.1",
+        "has-symbols": "1.0.0",
         "object-keys": "1.0.11"
       }
     },
@@ -8028,6 +8075,69 @@
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
       "requires": {
         "mimic-fn": "1.1.0"
+      }
+    },
+    "opencollective": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/opencollective/-/opencollective-1.0.3.tgz",
+      "integrity": "sha1-ruY3K8KBRFg2kMPKja7PwSDdDvE=",
+      "requires": {
+        "babel-polyfill": "6.23.0",
+        "chalk": "1.1.3",
+        "inquirer": "3.0.6",
+        "minimist": "1.2.0",
+        "node-fetch": "1.6.3",
+        "opn": "4.0.2"
+      },
+      "dependencies": {
+        "ansi-escapes": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+          "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4="
+        },
+        "inquirer": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.0.6.tgz",
+          "integrity": "sha1-4EqqnQW3o8ubD0B9BDdfBEcZA0c=",
+          "requires": {
+            "ansi-escapes": "1.4.0",
+            "chalk": "1.1.3",
+            "cli-cursor": "2.1.0",
+            "cli-width": "2.2.0",
+            "external-editor": "2.1.0",
+            "figures": "2.0.0",
+            "lodash": "4.17.4",
+            "mute-stream": "0.0.7",
+            "run-async": "2.3.0",
+            "rx": "4.1.0",
+            "string-width": "2.1.1",
+            "strip-ansi": "3.0.1",
+            "through": "2.3.8"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        },
+        "node-fetch": {
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.6.3.tgz",
+          "integrity": "sha1-3CNO3WSJmC1Y6PDbT2lQKavNjAQ=",
+          "requires": {
+            "encoding": "0.1.12",
+            "is-stream": "1.1.0"
+          }
+        },
+        "opn": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/opn/-/opn-4.0.2.tgz",
+          "integrity": "sha1-erwi5kTf9jsKltWrfyeQwPAavJU=",
+          "requires": {
+            "object-assign": "4.1.1",
+            "pinkie-promise": "2.0.1"
+          }
+        }
       }
     },
     "opn": {
@@ -9546,9 +9656,9 @@
       }
     },
     "prop-types": {
-      "version": "15.6.0",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.0.tgz",
-      "integrity": "sha1-zq8IMCL8RrSjX2nhPvda7Q1jmFY=",
+      "version": "15.6.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.1.tgz",
+      "integrity": "sha512-4ec7bY1Y66LymSUOH/zARVYObB23AT2h8cf6e/O6ZALB/N0sqZFEx7rq6EYPX2MkOdKORuooI/H5k9TlR4q7kQ==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
@@ -9587,9 +9697,9 @@
       }
     },
     "pubsub-js": {
-      "version": "1.5.7",
-      "resolved": "https://registry.npmjs.org/pubsub-js/-/pubsub-js-1.5.7.tgz",
-      "integrity": "sha1-qfOGrBQbCQWxnLst1XJWJl+XV0Q="
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/pubsub-js/-/pubsub-js-1.6.0.tgz",
+      "integrity": "sha1-Iy02SFznkFpUYp7FeD2fb0xjgCY="
     },
     "punycode": {
       "version": "1.4.1",
@@ -9741,14 +9851,14 @@
       }
     },
     "react": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.1.1.tgz",
-      "integrity": "sha512-FQfiFfk2z2Fk87OngNJHT05KyC9DOVn8LPeB7ZX+9u5+yU1JK6o5ozRlU3PeOMr0IFkWNvgn9jU8/IhRxR1F0g==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.2.0.tgz",
+      "integrity": "sha512-ZmIomM7EE1DvPEnSFAHZn9Vs9zJl5A9H7el0EGTE6ZbW9FKe/14IYAlPbC8iH25YarEQxZL+E8VW7Mi7kfQrDQ==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "react-dev-utils": {
@@ -9777,14 +9887,14 @@
       }
     },
     "react-dom": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.1.1.tgz",
-      "integrity": "sha512-q06jiwST8SEPAMIEkAsu7BgynEZtqF87VrTc70XsW7nxVhWEu2Y4MF5UfxxHQO/mNtQHQWP0YcFxmwm9oMrMaQ==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.2.0.tgz",
+      "integrity": "sha512-zpGAdwHVn9K0091d+hr+R0qrjoJ84cIBFL2uU60KvWBPfZ7LPSrfqviTxGHWN0sjPZb2hxWzMexwrvJdKePvjg==",
       "requires": {
         "fbjs": "0.8.16",
         "loose-envify": "1.3.1",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "react-error-overlay": {
@@ -9797,7 +9907,7 @@
       "resolved": "https://registry.npmjs.org/react-fontawesome/-/react-fontawesome-1.6.1.tgz",
       "integrity": "sha1-7dzhfn3HMaoJ/UoYZoimF5OhbFw=",
       "requires": {
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "react-media": {
@@ -9806,7 +9916,7 @@
       "integrity": "sha1-hOeYapI1axBtygJjY/j1yIBU/nI=",
       "requires": {
         "json2mq": "0.2.0",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "react-octicon": {
@@ -9815,20 +9925,49 @@
       "integrity": "sha512-OWL6CLI5hUTyS5h1bm2EcIqCxnuDfVBbUd/1VYs2Cqaz7IT24T9jhqaswyWgRWs2axuKY0xMJqR2SYt1BQtkQw==",
       "requires": {
         "octicons": "4.4.0",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
+      }
+    },
+    "react-reconciler": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.7.0.tgz",
+      "integrity": "sha512-50JwZ3yNyMS8fchN+jjWEJOH3Oze7UmhxeoJLn2j6f3NjpfCRbcmih83XTWmzqtar/ivd5f7tvQhvvhism2fgg==",
+      "dev": true,
+      "requires": {
+        "fbjs": "0.8.16",
+        "loose-envify": "1.3.1",
+        "object-assign": "4.1.1",
+        "prop-types": "15.6.1"
       }
     },
     "react-redux": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.6.tgz",
-      "integrity": "sha512-8taaaGu+J7PMJQDJrk/xiWEYQmdo3mkXw6wPr3K3LxvXis3Fymiq7c13S+Tpls/AyNUAsoONkU81AP0RA6y6Vw==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-5.0.7.tgz",
+      "integrity": "sha512-5VI8EV5hdgNgyjfmWzBbdrqUkrVRKlyTKk1sGH3jzM2M2Mhj/seQgPXaz6gVAj2lz/nz688AdTqMO18Lr24Zhg==",
       "requires": {
-        "hoist-non-react-statics": "2.3.1",
+        "hoist-non-react-statics": "2.5.0",
         "invariant": "2.2.2",
-        "lodash": "4.17.4",
-        "lodash-es": "4.17.4",
+        "lodash": "4.17.5",
+        "lodash-es": "4.17.7",
         "loose-envify": "1.3.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
+      },
+      "dependencies": {
+        "hoist-non-react-statics": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-2.5.0.tgz",
+          "integrity": "sha512-6Bl6XsDT1ntE0lHbIhr4Kp2PGcleGZ66qu5Jqk8lc0Xc/IeG6gVLmwUGs/K0Us+L8VWoKgj0uWdPMataOsm31w=="
+        },
+        "lodash": {
+          "version": "4.17.5",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+          "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+        },
+        "lodash-es": {
+          "version": "4.17.7",
+          "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.7.tgz",
+          "integrity": "sha512-jzqTi3vk4J5Dxq43cNjB0ekfCjPLHixoY2Sc0WHTo+0r928taLqe/VCt02vY5uQBvg0rdXgL3xWkK4X0MCmZcw=="
+        }
       }
     },
     "react-router": {
@@ -9841,7 +9980,7 @@
         "invariant": "2.2.2",
         "loose-envify": "1.3.1",
         "path-to-regexp": "1.7.0",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "warning": "3.0.0"
       }
     },
@@ -9853,7 +9992,7 @@
         "history": "4.7.2",
         "invariant": "2.2.2",
         "loose-envify": "1.3.1",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "react-router": "4.2.0",
         "warning": "3.0.0"
       }
@@ -9864,7 +10003,7 @@
       "integrity": "sha512-euSgNIANnRXr4GydIuwA7RZCefrLQzIw5WdXspS8NPYbV+FxrKSS9MKG7U9vb6vsKHONnA4VxrVNWfnMUnUQAw==",
       "requires": {
         "history": "4.7.2",
-        "prop-types": "15.6.0",
+        "prop-types": "15.6.1",
         "react-router": "4.2.0"
       }
     },
@@ -10716,13 +10855,13 @@
       }
     },
     "react-test-renderer": {
-      "version": "16.1.1",
-      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.1.1.tgz",
-      "integrity": "sha512-RV0Krfuc6wDnlv5C/BJzW3e2/s7ZTMZ25gfVjdXdT3hhXNDCQlZucP83HMD8mVh1XScGx9hRaXnIRJ7mE+2N6A==",
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.2.0.tgz",
+      "integrity": "sha512-Kd4gJFtpNziR9ElOE/C23LeflKLZPRpNQYWP3nQBY43SJ5a+xyEGSeMrm2zxNKXcnCbBS/q1UpD9gqd5Dv+rew==",
       "requires": {
         "fbjs": "0.8.16",
         "object-assign": "4.1.1",
-        "prop-types": "15.6.0"
+        "prop-types": "15.6.1"
       }
     },
     "read-all-stream": {
@@ -11176,6 +11315,11 @@
         "is-promise": "2.1.0"
       }
     },
+    "rx": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/rx/-/rx-4.1.0.tgz",
+      "integrity": "sha1-pfE/957zt0D+MKqAP7CfmIBdR4I="
+    },
     "rx-lite": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
@@ -11398,17 +11542,32 @@
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
     "sinon": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.1.3.tgz",
-      "integrity": "sha512-c7u0ZuvBRX1eXuB4jN3BRCAOGiUTlM8SE3TxbJHrNiHUKL7wonujMOB6Fi1gQc00U91IscFORQHDga/eccqpbw==",
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.4.6.tgz",
+      "integrity": "sha512-bzQag30yErCC4lJPv+C2HcmD1+3ula4JQNePZldKcagi0Exq6XDfcC2yqXVfEwtfTIq1rYGujrUIZbwHPpKjog==",
       "requires": {
+        "@sinonjs/formatio": "2.0.0",
         "diff": "3.4.0",
-        "formatio": "1.2.0",
         "lodash.get": "4.4.2",
-        "lolex": "2.3.1",
-        "nise": "1.2.0",
-        "supports-color": "4.5.0",
+        "lolex": "2.3.2",
+        "nise": "1.3.1",
+        "supports-color": "5.3.0",
         "type-detect": "4.0.5"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+        },
+        "supports-color": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+          "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+          "requires": {
+            "has-flag": "3.0.0"
+          }
+        }
       }
     },
     "slash": {
@@ -11723,24 +11882,26 @@
       }
     },
     "styled-components": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.0.2.tgz",
-      "integrity": "sha1-281m7oTURO5DMqf3QCfopnUZFZM=",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-3.2.3.tgz",
+      "integrity": "sha1-UPcSBzIO6x71Od7EY38h9ePJNrQ=",
       "requires": {
-        "buffer": "5.0.8",
-        "css-to-react-native": "2.0.4",
+        "buffer": "5.1.0",
+        "css-to-react-native": "2.1.2",
         "fbjs": "0.8.16",
         "hoist-non-react-statics": "1.2.0",
         "is-plain-object": "2.0.4",
-        "prop-types": "15.6.0",
-        "stylis": "3.4.8",
+        "opencollective": "1.0.3",
+        "prop-types": "15.6.1",
+        "stylis": "3.5.0",
+        "stylis-rule-sheet": "0.0.10",
         "supports-color": "3.2.3"
       },
       "dependencies": {
         "buffer": {
-          "version": "5.0.8",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.0.8.tgz",
-          "integrity": "sha512-xXvjQhVNz50v2nPeoOsNqWCLGfiv4ji/gXZM28jnVwdLJxH4mFyqgqCKfaK9zf1KUbG6zTkjLOy7ou+jSMarGA==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
+          "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
           "requires": {
             "base64-js": "1.2.1",
             "ieee754": "1.1.8"
@@ -11808,7 +11969,7 @@
             "fbjs": "0.8.16",
             "loose-envify": "1.3.1",
             "object-assign": "4.1.1",
-            "prop-types": "15.6.0"
+            "prop-types": "15.6.1"
           }
         },
         "styled-components": {
@@ -11822,7 +11983,7 @@
             "inline-style-prefixer": "2.0.5",
             "is-function": "1.0.1",
             "is-plain-object": "2.0.4",
-            "prop-types": "15.6.0",
+            "prop-types": "15.6.1",
             "supports-color": "3.2.3"
           }
         },
@@ -11837,9 +11998,14 @@
       }
     },
     "stylis": {
-      "version": "3.4.8",
-      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.4.8.tgz",
-      "integrity": "sha512-RVhA1z8dOpHP3hr5B//LrGQzh9sz6Merg4GuOJQu8ZxHP9GmR+cDE6LHkL6l76ASY8pfnsWa1ycjZKjSN2NvLA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-3.5.0.tgz",
+      "integrity": "sha512-pP7yXN6dwMzAR29Q0mBrabPCe0/mNO1MSr93bhay+hcZondvMMTpeGyd8nbhYJdyperNT2DRxONQuUGcJr5iPw=="
+    },
+    "stylis-rule-sheet": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
     },
     "supports-color": {
       "version": "4.5.0",
@@ -11940,9 +12106,9 @@
       "integrity": "sha1-mTcqXJmb8t8WCvwNdL7U9HlIzSI="
     },
     "tape": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/tape/-/tape-4.8.0.tgz",
-      "integrity": "sha512-TWILfEnvO7I8mFe35d98F6T5fbLaEtbFTG/lxWvid8qDfFTxt19EBijWmB4j3+Hoh5TfHE2faWs73ua+EphuBA==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/tape/-/tape-4.9.0.tgz",
+      "integrity": "sha512-j0jO9BiScfqtPBb9QmPLL0qvxXMz98xjkMb7x8lKipFlJZwNJkqkWPou+NU4V6T9RnVh1kuSthLE8gLrN8bBfw==",
       "requires": {
         "deep-equal": "1.0.1",
         "defined": "1.0.0",
@@ -11952,8 +12118,8 @@
         "has": "1.0.1",
         "inherits": "2.0.3",
         "minimist": "1.2.0",
-        "object-inspect": "1.3.0",
-        "resolve": "1.4.0",
+        "object-inspect": "1.5.0",
+        "resolve": "1.5.0",
         "resumer": "0.0.0",
         "string.prototype.trim": "1.1.2",
         "through": "2.3.8"
@@ -11963,14 +12129,6 @@
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
-        },
-        "resolve": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
-          "integrity": "sha512-aW7sVKPufyHqOmyyLzg/J+8606v5nevBgaliIlV7nUpVMsDnoBGV/cbSLNjZAg9q0Cfd/+easKVKQ8vOu8fn1Q==",
-          "requires": {
-            "path-parse": "1.0.5"
-          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "chai": "^4.1.2",
     "corewar": "0.0.72",
-    "enzyme-to-json": "^3.3.1",
+    "enzyme-to-json": "^3.3.3",
     "fetch-jsonp": "^1.1.3",
     "identicon.js": "^2.3.1",
     "immutable": "^3.8.2",
@@ -20,25 +20,25 @@
     "jest-styled-components": "^4.10.0",
     "jquery": "^3.3.1",
     "jssha": "^2.3.1",
-    "prop-types": "^15.6.0",
-    "pubsub-js": "^1.5.7",
-    "react": "^16.1.1",
-    "react-dom": "^16.1.1",
+    "prop-types": "^15.6.1",
+    "pubsub-js": "^1.6.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0",
     "react-fontawesome": "^1.6.1",
     "react-media": "1.6.1",
     "react-octicon": "^3.0.1",
-    "react-redux": "^5.0.6",
+    "react-redux": "^5.0.7",
     "react-router-dom": "^4.2.2",
     "react-router-redux": "next",
     "react-scripts": "1.0.17",
     "react-scroll-to-component": "^1.0.2",
-    "react-test-renderer": "^16.1.1",
+    "react-test-renderer": "^16.2.0",
     "redux": "^3.7.2",
     "redux-saga": "^0.16.0",
-    "sinon": "^4.1.3",
-    "styled-components": "^3.0.2",
+    "sinon": "^4.4.6",
+    "styled-components": "^3.2.3",
     "styled-property": "^1.0.2",
-    "tape": "^4.8.0",
+    "tape": "^4.9.0",
     "typeface-anonymous-pro": "0.0.44",
     "typeface-lato": "0.0.44"
   },
@@ -65,7 +65,7 @@
     ]
   },
   "devDependencies": {
-    "enzyme": "^3.2.0",
-    "enzyme-adapter-react-16": "^1.1.0"
+    "enzyme": "^3.3.0",
+    "enzyme-adapter-react-16": "^1.1.1"
   }
 }

--- a/src/features/app/appContainer.js
+++ b/src/features/app/appContainer.js
@@ -10,6 +10,7 @@ import Instructions from '../simulator/instructions'
 import Console from '../parser/console'
 import FileManagerContainer from '../fileManager/fileManagerContainer'
 import OcticonButton from '../common/octiconButton'
+import WarriorManagerContainer from '../warriorManager/warriorManagerContainer'
 
 import { space } from '../common/theme'
 
@@ -58,6 +59,7 @@ const AppContainer = ({ parse, currentWarrior,
         iconName={`terminal`}
         buttonText={`console`}
         />
+      <WarriorManagerContainer />
       <OcticonButton
         handleClick={toggleSettings}
         iconName={`gear`}

--- a/src/features/app/appContainer.js
+++ b/src/features/app/appContainer.js
@@ -59,6 +59,11 @@ const AppContainer = ({ parse, currentWarrior,
         iconName={`terminal`}
         buttonText={`console`}
         />
+      <OcticonButton
+        handleClick={addWarrior}
+        iconName={`plus`}
+        buttonText={`new file`}
+        />
       <WarriorManagerContainer />
       <OcticonButton
         handleClick={toggleSettings}

--- a/src/features/app/appContainer.js
+++ b/src/features/app/appContainer.js
@@ -50,11 +50,6 @@ const AppContainer = ({ parse, currentWarrior,
   <DesktopContainer>
     <Controls>
       <OcticonButton
-        enabled={hasNoErrors(currentWarrior)}
-        handleClick={addWarrior}
-        iconName={`plus`}
-        buttonText={`add`} />
-      <OcticonButton
         handleClick={toggleFileManager}
         iconName={`file-directory`}
         buttonText={`files`} />
@@ -98,9 +93,6 @@ const AppContainer = ({ parse, currentWarrior,
   </DesktopContainer>
 )
 
-const hasNoErrors = (currentWarrior) => (
-  currentWarrior.compiled && currentWarrior.messages.filter(x => x.type === 0).length === 0
-)
 
 const mapStateToProps = state => ({
   currentWarrior: state.parser.currentWarrior,

--- a/src/features/common/controls.js
+++ b/src/features/common/controls.js
@@ -22,6 +22,8 @@ const Controls = styled.div`
     border-top: 1px solid ${colour.lightbg};
   `}
 
+  grid-column: 1 / 3;
+
   display: flex;
   flex-direction: row;
   justify-content: space-around;

--- a/src/features/common/headerControls.js
+++ b/src/features/common/headerControls.js
@@ -9,7 +9,7 @@ const Controls = styled.div`
   text-align: center;
 
   display: grid;
-  grid-template-columns: 100px 100px 1fr 100px
+  grid-template-columns: 100px 100px 100px 1fr 100px
 `
 
 export default Controls

--- a/src/features/common/headerControls.js
+++ b/src/features/common/headerControls.js
@@ -9,7 +9,7 @@ const Controls = styled.div`
   text-align: center;
 
   display: grid;
-  grid-template-columns: repeat(10, 1fr)
+  grid-template-columns: 100px 100px 1fr 100px
 `
 
 export default Controls

--- a/src/features/common/identicon.js
+++ b/src/features/common/identicon.js
@@ -12,12 +12,12 @@ export const createHash = (input) => {
   return sha.getHash('HEX')
 }
 
-export const getIdenticon = (compiled, i, size) => {
+export const getIdenticon = (compiled, i, size = 40) => {
 
   const hash = createHash(compiled)
 
   const options = {
-    size: size ? size : 40,
+    size: size,
     foreground: hexToRgbA(colour.warrior[i]),
     background: [0,0,0,0],
     margin: 0,

--- a/src/features/common/mobilePage.js
+++ b/src/features/common/mobilePage.js
@@ -14,6 +14,7 @@ const MobilePage = styled.main`
 
   display: grid;
   grid-template-rows: 1fr ${space.controls};
+  grid-template-columns: ${space.sidebar} 1fr;
 `
 
 export default MobilePage

--- a/src/features/common/theme.js
+++ b/src/features/common/theme.js
@@ -29,7 +29,8 @@ export const space = {
   xl: '64px',
   xxl: '128px',
   header: '48px',
-  controls: '48px'
+  controls: '48px',
+  sidebar: '64px'
 }
 
 export const icon = {

--- a/src/features/common/warriorPanel.js
+++ b/src/features/common/warriorPanel.js
@@ -5,8 +5,13 @@ import { media } from '../common/mediaQuery'
 
 const WarriorPanel = styled.section`
 
-  ${media.tablet`
-    height: calc(100vh - ${space.controls} - ${space.controls} - ${space.s} - ${space.controls});
+
+
+  ${media.desktop`
+    height: calc(100vh - ${space.controls} - ${space.controls});
+  `}
+  ${media.phone`
+     height: calc(100vh - ${space.controls} - ${space.controls} - ${space.s} - ${space.controls});
   `}
 
   border-right: 1px solid ${colour.lightbg};
@@ -15,7 +20,7 @@ const WarriorPanel = styled.section`
   flex-direction: row;
   flex-wrap: wrap;
 
-  ${media.tablet`
+  ${media.desktop`
     flex-direction: column;
     align-items: flex-start;
   `}

--- a/src/features/common/warriorPanel.js
+++ b/src/features/common/warriorPanel.js
@@ -1,14 +1,24 @@
 import styled from 'styled-components'
 
 import { colour, space } from '../common/theme'
+import { media } from '../common/mediaQuery'
 
 const WarriorPanel = styled.section`
-  height: calc(100vh - ${space.controls} - ${space.controls} - ${space.s} - ${space.controls});
+
+  ${media.tablet`
+    height: calc(100vh - ${space.controls} - ${space.controls} - ${space.s} - ${space.controls});
+  `}
+
   border-right: 1px solid ${colour.lightbg};
+
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   flex-wrap: wrap;
-  align-items: flex-start;
+
+  ${media.tablet`
+    flex-direction: column;
+    align-items: flex-start;
+  `}
 
   .octicon {
     padding-left: 4px;

--- a/src/features/common/warriorPanel.js
+++ b/src/features/common/warriorPanel.js
@@ -9,6 +9,10 @@ const WarriorPanel = styled.section`
   flex-direction: column;
   flex-wrap: wrap;
   align-items: flex-start;
+
+  .octicon {
+    padding-left: 4px;
+  }
 `
 
 export default WarriorPanel

--- a/src/features/common/warriorPanel.js
+++ b/src/features/common/warriorPanel.js
@@ -3,16 +3,12 @@ import styled from 'styled-components'
 import { colour, space } from '../common/theme'
 
 const WarriorPanel = styled.section`
-  grid-row: 1 / 3;
-  height: 100%;
+  height: calc(100vh - ${space.controls} - ${space.controls} - ${space.s} - ${space.controls});
   border-right: 1px solid ${colour.lightbg};
   display: flex;
   flex-direction: column;
   flex-wrap: wrap;
   align-items: flex-start;
-  padding: ${space.m} 0;
-
-  overflow-y: scroll;
 `
 
 export default WarriorPanel

--- a/src/features/common/warriorPanel.js
+++ b/src/features/common/warriorPanel.js
@@ -1,0 +1,18 @@
+import styled from 'styled-components'
+
+import { colour, space } from '../common/theme'
+
+const WarriorPanel = styled.section`
+  grid-row: 1 / 3;
+  height: 100%;
+  border-right: 1px solid ${colour.lightbg};
+  display: flex;
+  flex-direction: column;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  padding: ${space.m} 0;
+
+  overflow-y: scroll;
+`
+
+export default WarriorPanel

--- a/src/features/notifications/notificationContainer.js
+++ b/src/features/notifications/notificationContainer.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 
-import { space } from '../common/theme'
+import { space, colour } from '../common/theme'
 
 const NotificationWrapper = styled.div`
 
@@ -13,12 +13,10 @@ const NotificationWrapper = styled.div`
   right: 0;
   width: 50%;
   max-width: 300px;
-  min-height: 30px;
-  line-height: 30px;
-  height: auto;
 
-  background-color: #fff;
-  color: #000;
+
+  background-color: ${colour.lightbg};
+  color: ${colour.blue};
   text-align: center;
   padding: ${space.s};
   margin-bottom: ${space.s};
@@ -28,6 +26,8 @@ const NotificationWrapper = styled.div`
 const NotficationItem = styled.div`
   margin-bottom: ${space.s};
   margin-top: ${space.s};
+  line-height: ${space.m};
+  height: ${space.m};
 `
 
 const NotificationContainer = ({ notifications }) => (

--- a/src/features/parser/actions.js
+++ b/src/features/parser/actions.js
@@ -8,11 +8,13 @@ export const TOGGLE_FILE_MANAGER = 'parser/TOGGLE_FILE_MANAGER'
 export const SET_WARRIORS = 'parser/SET_WARRIORS'
 export const LOAD_WARRIOR = 'parser/LOAD_WARRIOR'
 export const SET_CURRENT_FILE_INDEX = 'parser/SET_CURRENT_FILE_INDEX'
+export const TOGGLE_WARRIOR = 'parser/TOGGLE_WARRIOR'
 
 export const PARSE_REQUESTED = 'parser/PARSE_REQUESTED'
 export const ADD_WARRIOR_REQUESTED = 'parser/ADD_WARRIOR_REQUESTED'
 export const REMOVE_WARRIOR_REQUESTED = 'parser/REMOVE_WARRIOR_REQUESTED'
 export const LOAD_WARRIOR_REQUESTED = 'parser/LOAD_WARRIOR_REQUESTED'
+export const TOGGLE_WARRIOR_REQUESTED = 'parser/TOGGLE_WARRIOR_REQUESTED'
 
 export const parse = source => action(PARSE_REQUESTED, { source })
 export const addWarrior = () => action(ADD_WARRIOR_REQUESTED)
@@ -22,3 +24,4 @@ export const showConsole = () => action(SHOW_CONSOLE)
 export const hideConsole = () => action(HIDE_CONSOLE)
 export const toggleFileManager = () => action(TOGGLE_FILE_MANAGER)
 export const loadWarrior = (hash, i) => action(LOAD_WARRIOR_REQUESTED, { hash, i })
+export const toggleWarrior = i => action(TOGGLE_WARRIOR_REQUESTED, { i })

--- a/src/features/parser/actions.js
+++ b/src/features/parser/actions.js
@@ -7,6 +7,7 @@ export const SHOW_CONSOLE = 'parser/SHOW_CONSOLE'
 export const TOGGLE_FILE_MANAGER = 'parser/TOGGLE_FILE_MANAGER'
 export const SET_WARRIORS = 'parser/SET_WARRIORS'
 export const LOAD_WARRIOR = 'parser/LOAD_WARRIOR'
+export const SET_CURRENT_FILE_INDEX = 'parser/SET_CURRENT_FILE_INDEX'
 
 export const PARSE_REQUESTED = 'parser/PARSE_REQUESTED'
 export const ADD_WARRIOR_REQUESTED = 'parser/ADD_WARRIOR_REQUESTED'
@@ -20,4 +21,4 @@ export const toggleConsole = () => action(TOGGLE_CONSOLE)
 export const showConsole = () => action(SHOW_CONSOLE)
 export const hideConsole = () => action(HIDE_CONSOLE)
 export const toggleFileManager = () => action(TOGGLE_FILE_MANAGER)
-export const loadWarrior = guid => action(LOAD_WARRIOR_REQUESTED, { guid })
+export const loadWarrior = (hash, i) => action(LOAD_WARRIOR_REQUESTED, { hash, i })

--- a/src/features/parser/combinedContainer.js
+++ b/src/features/parser/combinedContainer.js
@@ -8,6 +8,7 @@ import Console from './console'
 import MobilePage from '../common/mobilePage'
 import ControlsContainer from '../parser/controlsContainer'
 import FileManagerContainer from '../fileManager/fileManagerContainer'
+import WarriorManagerContainer from '../warriorManager/warriorManagerContainer'
 
 import { space } from '../common/theme'
 
@@ -23,6 +24,7 @@ const ParserGrid = styled.section`
 
 const ParserInterface = ({ redcode, parse, currentWarrior, addWarrior, hideConsole, displayConsole }) => (
   <MobilePage tablet>
+    <WarriorManagerContainer />
     <ParserGrid>
       <SourceCodeTextArea
         value={redcode}

--- a/src/features/parser/combinedContainer.js
+++ b/src/features/parser/combinedContainer.js
@@ -22,12 +22,12 @@ const ParserGrid = styled.section`
   height: calc(100vh - ${space.header} - ${space.controls});
 `
 
-const ParserInterface = ({ redcode, parse, currentWarrior, addWarrior, hideConsole, displayConsole }) => (
+const ParserInterface = ({ parse, currentWarrior, addWarrior, hideConsole, displayConsole }) => (
   <MobilePage tablet>
     <WarriorManagerContainer />
     <ParserGrid>
       <SourceCodeTextArea
-        value={redcode}
+        value={currentWarrior.source}
         handleChange={e => parse(e.target.value)} />
       <CompiledOutput tablet>
         {currentWarrior.compiled}

--- a/src/features/parser/controlsContainer.js
+++ b/src/features/parser/controlsContainer.js
@@ -14,11 +14,6 @@ import {
 const MobileControls = ({ addWarrior, currentWarrior, toggleConsole, toggleFileManager }) => (
   <Controls>
     <OcticonButton
-      enabled={hasNoErrors(currentWarrior)}
-      handleClick={addWarrior}
-      iconName={`plus`}
-      buttonText={`add`} />
-    <OcticonButton
       handleClick={toggleFileManager}
       iconName={`file-directory`}
       buttonText={`files`} />
@@ -28,10 +23,6 @@ const MobileControls = ({ addWarrior, currentWarrior, toggleConsole, toggleFileM
       iconName={`terminal`}
       buttonText={`console`} />
   </Controls>
-)
-
-const hasNoErrors = (currentWarrior) => (
-  currentWarrior.compiled && currentWarrior.messages.filter(x => x.type === 0).length === 0
 )
 
 MobileControls.PropTypes = {

--- a/src/features/parser/inputContainer.js
+++ b/src/features/parser/inputContainer.js
@@ -6,6 +6,7 @@ import SourceCodeTextArea from './sourceCodeTextArea'
 import Console from './console'
 import FileManagerContainer from '../fileManager/fileManagerContainer'
 import ControlsContainer from '../parser/controlsContainer'
+import WarriorManagerContainer from '../warriorManager/warriorManagerContainer'
 
 import {
   parse,
@@ -14,6 +15,7 @@ import {
 
 const InputContainer = ({ parse, currentWarrior, hideConsole, displayConsole }) => (
   <MobilePage mobile>
+    <WarriorManagerContainer />
     <SourceCodeTextArea
       value={currentWarrior.source}
       handleChange={e => parse(e.target.value)} />

--- a/src/features/parser/outputContainer.js
+++ b/src/features/parser/outputContainer.js
@@ -5,9 +5,11 @@ import MobilePage from '../common/mobilePage'
 import CompiledOutput from './compiledOutput'
 import ControlsContainer from './controlsContainer'
 import FileManagerContainer from '../fileManager/fileManagerContainer'
+import WarriorPanel from '../common/warriorPanel'
 
 const OutputInterface = ({ currentWarrior }) => (
   <MobilePage mobile>
+    <WarriorPanel />
     <CompiledOutput mobile>
       {currentWarrior.compiled}
     </CompiledOutput>

--- a/src/features/parser/outputContainer.js
+++ b/src/features/parser/outputContainer.js
@@ -5,11 +5,11 @@ import MobilePage from '../common/mobilePage'
 import CompiledOutput from './compiledOutput'
 import ControlsContainer from './controlsContainer'
 import FileManagerContainer from '../fileManager/fileManagerContainer'
-import WarriorPanel from '../common/warriorPanel'
+import WarriorManagerContainer from '../warriorManager/warriorManagerContainer'
 
 const OutputInterface = ({ currentWarrior }) => (
   <MobilePage mobile>
-    <WarriorPanel />
+    <WarriorManagerContainer />
     <CompiledOutput mobile>
       {currentWarrior.compiled}
     </CompiledOutput>

--- a/src/features/parser/reducer.js
+++ b/src/features/parser/reducer.js
@@ -38,9 +38,10 @@ export default (state = initialState, action) => {
       }
 
     case SET_CURRENT_FILE_INDEX:
+      console.log('file index', action.currentFileIndex)
       return {
         ...state,
-        currentFileIndex: action.fileIndex
+        currentFileIndex: action.currentFileIndex
       }
 
     case SET_WARRIORS:

--- a/src/features/parser/reducer.js
+++ b/src/features/parser/reducer.js
@@ -10,25 +10,13 @@ import {
 } from './actions'
 
 import { defaultWarriors } from '../../helpers/defaultWarriors'
-
-const defaultFile = {
-  source: '',
-  compiled: '',
-  hasErrors: false,
-  hash: '',
-  icon: null,
-  metaData: {
-    name: 'new file',
-    author: 'anonymous'
-  },
-  tokens: []
-}
+import newWarrior from '../../helpers/newWarrior'
 
 // state
 const initialState = {
   currentFileIndex: 0,
-  currentWarrior: defaultFile,
-  warriors: [defaultFile],
+  currentWarrior: newWarrior,
+  warriors: [newWarrior],
   warriorLibrary: defaultWarriors,
   standardId: 2, // TODO: what's the best standard to use as a default?
   displayConsole: false,

--- a/src/features/parser/reducer.js
+++ b/src/features/parser/reducer.js
@@ -11,11 +11,24 @@ import {
 
 import { defaultWarriors } from '../../helpers/defaultWarriors'
 
+const defaultFile = {
+  source: '',
+  compiled: '',
+  hasErrors: false,
+  hash: '',
+  icon: null,
+  metaData: {
+    name: 'new file',
+    author: 'anonymous'
+  },
+  tokens: []
+}
+
 // state
 const initialState = {
   currentFileIndex: 0,
-  currentWarrior: {},
-  warriors: [],
+  currentWarrior: defaultFile,
+  warriors: [defaultFile],
   warriorLibrary: defaultWarriors,
   standardId: 2, // TODO: what's the best standard to use as a default?
   displayConsole: false,

--- a/src/features/parser/reducer.js
+++ b/src/features/parser/reducer.js
@@ -5,13 +5,15 @@ import {
   SHOW_CONSOLE,
   TOGGLE_FILE_MANAGER,
   SET_WARRIORS,
-  LOAD_WARRIOR
+  LOAD_WARRIOR,
+  SET_CURRENT_FILE_INDEX
 } from './actions'
 
 import { defaultWarriors } from '../../helpers/defaultWarriors'
 
 // state
 const initialState = {
+  currentFileIndex: 0,
   currentWarrior: {},
   warriors: [],
   warriorLibrary: defaultWarriors,
@@ -34,6 +36,12 @@ export default (state = initialState, action) => {
         currentWarrior: action.currentWarrior
       }
 
+    case SET_CURRENT_FILE_INDEX:
+      return {
+        ...state,
+        currentFileIndex: action.fileIndex
+      }
+
     case SET_WARRIORS:
       return {
         ...state,
@@ -53,7 +61,6 @@ export default (state = initialState, action) => {
       }
 
     case HIDE_CONSOLE:
-      console.log('hide')
       return {
         ...state,
         displayConsole: false

--- a/src/features/parser/reducer.js
+++ b/src/features/parser/reducer.js
@@ -38,7 +38,6 @@ export default (state = initialState, action) => {
       }
 
     case SET_CURRENT_FILE_INDEX:
-      console.log('file index', action.currentFileIndex)
       return {
         ...state,
         currentFileIndex: action.currentFileIndex

--- a/src/features/parser/sagas.js
+++ b/src/features/parser/sagas.js
@@ -14,7 +14,8 @@ import {
   HIDE_CONSOLE,
   SET_WARRIORS,
   LOAD_WARRIOR_REQUESTED,
-  LOAD_WARRIOR
+  LOAD_WARRIOR,
+  SET_CURRENT_FILE_INDEX
 } from './actions'
 
 import { PAUSE } from '../simulator/actions'
@@ -53,6 +54,8 @@ export function* addWarriorSaga() {
 
   const icon = getIdenticon(currentWarrior.compiled, warriors.length)
 
+  yield put({ type: SET_CURRENT_FILE_INDEX, fileIndex: warriors.length })
+
   const warriorList = yield call(insertItem, warriors.length, warriors, { ...currentWarrior, icon })
 
   yield put({ type: SET_WARRIORS, warriors: warriorList })
@@ -62,11 +65,13 @@ export function* addWarriorSaga() {
   yield call(toast, 'Warrior Added')
 }
 
-export function* loadWarriorSaga({ hash }) {
+export function* loadWarriorSaga({ hash, i }) {
 
   const { warriors } = yield select(getParserState)
 
   const warrior = warriors.find(x => x.hash === hash)
+
+  yield put({ type: SET_CURRENT_FILE_INDEX, fileIndex: i })
 
   yield put({ type: LOAD_WARRIOR, warrior })
 
@@ -79,6 +84,12 @@ export function* removeWarriorSaga({ index }) {
   const data = yield call(getCoreOptionsFromState)
 
   const { warriors } = yield select(getParserState)
+
+  if(index === warriors.length) {
+    console.log('yup')
+    console.log(index - 1)
+    yield put({ type: SET_CURRENT_FILE_INDEX, fileIndex: index - 1 })
+  }
 
   const warriorList = yield call(removeItem, index, warriors)
 

--- a/src/features/parser/sagas.js
+++ b/src/features/parser/sagas.js
@@ -50,7 +50,6 @@ export function* parseWarriorSaga({ source }) {
 
   yield put({ type: PAUSE })
 
-  // parse the warrior
   const parseResult = yield call([corewar, corewar.parse], source)
 
   const hasErrors = parseResult.messages.find(x => x.type === 0)
@@ -65,7 +64,8 @@ export function* parseWarriorSaga({ source }) {
 
   const currentWarrior = { ...parseResult, compiled, source, hash, icon, hasErrors }
 
-  // check for errors / messages
+  yield put({ type: PARSE, currentWarrior })
+
   if(hasErrors){
     yield put({ type: SHOW_CONSOLE })
   } else {
@@ -80,7 +80,6 @@ export function* parseWarriorSaga({ source }) {
     yield call(initialiseCore, data.options, warriorList.filter(x => !x.hasErrors))
   }
 
-  yield put({ type: PARSE, currentWarrior })
 
 }
 

--- a/src/features/parser/sagas.js
+++ b/src/features/parser/sagas.js
@@ -117,24 +117,21 @@ export function* loadWarriorSaga({ hash, i }) {
 
 export function* toggleWarriorSaga({ i }) {
 
-  // TODO: need to differentiate between warriors in and out of the core
-  // files & warriors?
-  // warriors { active: t/f }?
   const { warriors } = yield select(getParserState)
 
   const warrior = warriors[i]
 
-  const removedList = yield call(removeItem, i, warriors)
-  // // TODO: prevent toggle, or even option to toggle if there are errors?
-  // const hasErrors = warrior.hasErrors
-  // const activeIntent = !warrior.active
-  const warriorList = yield call(insertItem, i, removedList, { ...warrior, active: !warrior.active })
+  const updatedList = yield call(replaceItem, i, warriors, { ...warrior, active: !warrior.active })
 
-  yield put({ type: SET_WARRIORS, warriors: warriorList })
+  yield put({ type: SET_WARRIORS, warriors: updatedList })
 
   const data = yield call(getCoreOptionsFromState)
 
-  yield call(initialiseCore, data.options, warriorList.filter(x => !x.hasErrors && x.active))
+  const activeList =  updatedList.filter(x => !x.hasErrors && x.active)
+
+  console.log(activeList)
+
+  yield call(initialiseCore, data.options, activeList)
 
 }
 

--- a/src/features/parser/sagas.js
+++ b/src/features/parser/sagas.js
@@ -67,8 +67,11 @@ export function* parseWarriorSaga({ source }) {
   yield put({ type: PARSE, currentWarrior })
 
   if(hasErrors){
+
     yield put({ type: SHOW_CONSOLE })
+
   } else {
+
     yield put({ type: HIDE_CONSOLE })
 
     const warriorList = yield call(replaceItem, currentFileIndex, warriors, currentWarrior)
@@ -78,8 +81,8 @@ export function* parseWarriorSaga({ source }) {
     const data = yield call(getCoreOptionsFromState)
 
     yield call(initialiseCore, data.options, warriorList.filter(x => !x.hasErrors))
-  }
 
+  }
 
 }
 
@@ -91,15 +94,11 @@ export function* addWarriorSaga() {
 
   const { warriors, currentWarrior } = yield select(getParserState)
 
-  console.log('add', warriors)
-
   const icon = getIdenticon(currentWarrior.compiled, warriors.length)
 
-  yield put({ type: SET_CURRENT_FILE_INDEX, fileIndex: warriors.length })
+  yield put({ type: SET_CURRENT_FILE_INDEX, currentFileIndex: warriors.length })
 
   const warriorList = yield call(insertItem, warriors.length, warriors, { ...currentWarrior, icon })
-
-  console.log('add', warriorList)
 
   yield put({ type: SET_WARRIORS, warriors: warriorList })
 
@@ -114,7 +113,7 @@ export function* loadWarriorSaga({ hash, i }) {
 
   const warrior = warriors.find(x => x.hash === hash)
 
-  yield put({ type: SET_CURRENT_FILE_INDEX, fileIndex: i })
+  yield put({ type: SET_CURRENT_FILE_INDEX, currentFileIndex: i })
 
   yield put({ type: LOAD_WARRIOR, warrior })
 
@@ -143,10 +142,16 @@ export function* removeWarriorSaga({ index }) {
 
   const data = yield call(getCoreOptionsFromState)
 
-  const { warriors } = yield select(getParserState)
+  const { warriors, currentFileIndex } = yield select(getParserState)
 
-  if(index === warriors.length) {
-    yield put({ type: SET_CURRENT_FILE_INDEX, fileIndex: index - 1 })
+  console.log('removalindex', index)
+  console.log('currentFileIndex', currentFileIndex)
+  console.log('warriorLength - pre', warriors.length)
+
+  if(index === warriors.length - 1) {
+    const newIndex = index - 1
+    console.log('doing it', newIndex)
+    yield put({ type: SET_CURRENT_FILE_INDEX, currentFileIndex: newIndex })
   }
 
   const warriorList = yield call(removeItem, index, warriors)

--- a/src/features/parser/sagas.js
+++ b/src/features/parser/sagas.js
@@ -26,26 +26,6 @@ import { getParserState } from './reducer'
 import { getCoreOptionsFromState, initialiseCore } from '../simulator/sagas'
 
 // sagas
-export function* parseSaga({ source }) {
-
-  const parseResult = yield call([corewar, corewar.parse], source)
-
-  const compiled = yield call([corewar, corewar.serialise], parseResult.tokens)
-
-  const hash = createHash(compiled)
-
-  const currentWarrior = { ...parseResult, compiled, source, hash, active: true }
-
-  if(currentWarrior.messages.find(x => x.type === 0)){
-    yield put({ type: SHOW_CONSOLE })
-  } else {
-    yield put({ type: HIDE_CONSOLE })
-  }
-
-  yield put({ type: PARSE, currentWarrior })
-
-}
-
 export function* parseWarriorSaga({ source }) {
 
   yield put({ type: PAUSE })
@@ -60,7 +40,7 @@ export function* parseWarriorSaga({ source }) {
 
   const { warriors, currentFileIndex } = yield select(getParserState)
 
-  const icon = getIdenticon(compiled, currentFileIndex)
+  const icon = getIdenticon(compiled, currentFileIndex, 20)
 
   const currentWarrior = { ...parseResult, compiled, source, hash, icon, hasErrors, active: warriors[currentFileIndex].active }
 
@@ -90,7 +70,7 @@ export function* addWarriorSaga() {
 
   const { warriors, currentWarrior } = yield select(getParserState)
 
-  const icon = getIdenticon(currentWarrior.compiled, warriors.length)
+  const icon = getIdenticon(currentWarrior.compiled, warriors.length, 20)
 
   yield put({ type: SET_CURRENT_FILE_INDEX, currentFileIndex: warriors.length })
 
@@ -151,7 +131,7 @@ export function* removeWarriorSaga({ index }) {
   }
 
   const newIcons = warriorList.map((warrior, i) =>
-    ({ ...warrior, icon: getIdenticon(warrior.compiled, i) })
+    ({ ...warrior, icon: getIdenticon(warrior.compiled, i, 20) })
   )
 
   yield put({ type: SET_WARRIORS, warriors: newIcons })

--- a/src/features/parser/sagas.js
+++ b/src/features/parser/sagas.js
@@ -15,6 +15,8 @@ import {
   SET_WARRIORS,
   LOAD_WARRIOR_REQUESTED,
   LOAD_WARRIOR,
+  TOGGLE_WARRIOR_REQUESTED,
+  TOGGLE_WARRIOR,
   SET_CURRENT_FILE_INDEX
 } from './actions'
 
@@ -32,7 +34,7 @@ export function* parseSaga({ source }) {
 
   const hash = createHash(compiled)
 
-  const currentWarrior = { ...parseResult, compiled, source, hash }
+  const currentWarrior = { ...parseResult, compiled, source, hash, active: true }
 
   if(currentWarrior.messages.find(x => x.type === 0)){
     yield put({ type: SHOW_CONSOLE })
@@ -77,6 +79,19 @@ export function* loadWarriorSaga({ hash, i }) {
 
 }
 
+export function* toggleWarriorSaga({ i }) {
+
+  const { warriors } = yield select(getParserState)
+
+  const warrior = warriors[i]
+
+  const removedList = yield call(removeItem, i, warriors)
+  const warriorList = yield call(insertItem, i, removedList, { ...warrior, active: !warrior.active })
+
+  yield put({ type: SET_WARRIORS, warriors: warriorList })
+
+}
+
 export function* removeWarriorSaga({ index }) {
 
   yield put({ type: PAUSE })
@@ -108,5 +123,6 @@ export const parserWatchers = [
   takeLatest(PARSE_REQUESTED, parseSaga),
   takeEvery(ADD_WARRIOR_REQUESTED, addWarriorSaga),
   takeEvery(REMOVE_WARRIOR_REQUESTED, removeWarriorSaga),
-  takeEvery(LOAD_WARRIOR_REQUESTED, loadWarriorSaga)
+  takeEvery(LOAD_WARRIOR_REQUESTED, loadWarriorSaga),
+  takeEvery(TOGGLE_WARRIOR_REQUESTED, toggleWarriorSaga)
 ]

--- a/src/features/parser/sagas.js
+++ b/src/features/parser/sagas.js
@@ -146,17 +146,12 @@ export function* removeWarriorSaga({ index }) {
 
   const { warriors, currentFileIndex } = yield select(getParserState)
 
-  console.log('removalindex', index)
-  console.log('currentFileIndex', currentFileIndex)
-  console.log('warriorLength - pre', warriors.length)
+  const warriorList = yield call(removeItem, index, warriors)
 
-  if(index === warriors.length - 1) {
+  if(index === warriorList.length) {
     const newIndex = index - 1
-    console.log('doing it', newIndex)
     yield put({ type: SET_CURRENT_FILE_INDEX, currentFileIndex: newIndex })
   }
-
-  const warriorList = yield call(removeItem, index, warriors)
 
   const newIcons = warriorList.map((warrior, i) =>
     ({ ...warrior, icon: getIdenticon(warrior.compiled, i) })

--- a/src/features/parser/sagas.js
+++ b/src/features/parser/sagas.js
@@ -86,8 +86,6 @@ export function* removeWarriorSaga({ index }) {
   const { warriors } = yield select(getParserState)
 
   if(index === warriors.length) {
-    console.log('yup')
-    console.log(index - 1)
     yield put({ type: SET_CURRENT_FILE_INDEX, fileIndex: index - 1 })
   }
 

--- a/src/features/simulator/core.js
+++ b/src/features/simulator/core.js
@@ -133,6 +133,7 @@ class CanvasCore extends Component {
 
       this.sprites.push(sprites)
     })
+
   }
 
   buildSprite() {

--- a/src/features/simulator/core.js
+++ b/src/features/simulator/core.js
@@ -104,7 +104,7 @@ class CanvasCore extends Component {
 
     this.interactiveCanvas.addEventListener("click", e => this.canvasClick(e))
 
-    window.addEventListener('resize', throttle(() => this.redraw(), 200))
+    window.addEventListener('resize', throttle(() => this.init(), 200))
 
     window.requestAnimationFrame(() => this.renderMessages())
 
@@ -117,10 +117,6 @@ class CanvasCore extends Component {
       this.hasLoaded = true
       this.init()
     }
-  }
-
-  redraw() {
-    this.init()
   }
 
   buildSprites() {

--- a/src/features/simulator/core.js
+++ b/src/features/simulator/core.js
@@ -295,10 +295,6 @@ class CanvasCore extends Component {
     return y * this.cellsWide + x
   }
 
-  getColour(warriorId) {
-    return colour.warrior[warriorId]
-  }
-
   renderCell(event) {
 
     const coordinate = this.addressToScreenCoordinate(event.address)

--- a/src/features/simulator/sagas.js
+++ b/src/features/simulator/sagas.js
@@ -140,13 +140,9 @@ export function* initialiseCore(options, warriors) {
 
   yield call(PubSub.publishSync, 'RESET_CORE')
 
-  if(warriors.length > 0) {
+  yield call([corewar, corewar.initialiseSimulator], options, warriors, PubSub)
 
-    yield call([corewar, corewar.initialiseSimulator], options, warriors, PubSub)
-
-    yield put({ type: INIT })
-
-  }
+  yield put({ type: INIT })
 
 }
 

--- a/src/features/simulator/simulatorLayout.js
+++ b/src/features/simulator/simulatorLayout.js
@@ -6,7 +6,7 @@ import ErrorBoundary from '../common/errorBoundary'
 import Warriors from './warriors'
 import ControlsContainer from './controlsContainer'
 import SettingsMenuContainer from '../settingsMenu/settingsMenuContainer'
-import WarriorPanel from '../common/warriorPanel'
+import WarriorManagerContainer from '../warriorManager/warriorManagerContainer'
 
 import { space, colour } from  '../common/theme'
 import { media } from  '../common/mediaQuery'
@@ -35,8 +35,7 @@ SimulatorGrid.displayName = `SimulatorGrid`
 const SimulatorLayout = ({ coreSize, getCoreInstructions, isRunning, isInitialised,
   init, warriors, maxTasks, removeWarrior, loadWarrior, republish, tablet, mobile }) => (
   <SimulatorGrid mobile={mobile} tablet={tablet}>
-    {(mobile || tablet) && <WarriorPanel /> }
-    {/* <Warriors warriors={warriors} maxTasks={maxTasks} removeWarrior={removeWarrior} loadWarrior={loadWarrior} /> */}
+    {(mobile || tablet) && <WarriorManagerContainer /> }
     <ErrorBoundary>
       <Core
         init={init}

--- a/src/features/simulator/simulatorLayout.js
+++ b/src/features/simulator/simulatorLayout.js
@@ -6,6 +6,7 @@ import ErrorBoundary from '../common/errorBoundary'
 import Warriors from './warriors'
 import ControlsContainer from './controlsContainer'
 import SettingsMenuContainer from '../settingsMenu/settingsMenuContainer'
+import WarriorPanel from '../common/warriorPanel'
 
 import { space, colour } from  '../common/theme'
 import { media } from  '../common/mediaQuery'
@@ -24,7 +25,8 @@ const SimulatorGrid = styled.section`
   ${media.phone`min-height: 400px;`}
 
   display: grid;
-  grid-template-rows: 75px 1fr ${space.controls};
+  grid-template-rows: 1fr ${space.controls};
+  grid-template-columns: ${space.sidebar} 1fr;
   background-color: ${colour.defaultbg};
 `
 
@@ -33,7 +35,8 @@ SimulatorGrid.displayName = `SimulatorGrid`
 const SimulatorLayout = ({ coreSize, getCoreInstructions, isRunning, isInitialised,
   init, warriors, maxTasks, removeWarrior, loadWarrior, republish, tablet, mobile }) => (
   <SimulatorGrid mobile={mobile} tablet={tablet}>
-    <Warriors warriors={warriors} maxTasks={maxTasks} removeWarrior={removeWarrior} loadWarrior={loadWarrior} />
+    {(mobile || tablet) && <WarriorPanel /> }
+    {/* <Warriors warriors={warriors} maxTasks={maxTasks} removeWarrior={removeWarrior} loadWarrior={loadWarrior} /> */}
     <ErrorBoundary>
       <Core
         init={init}

--- a/src/features/simulator/simulatorLayout.js
+++ b/src/features/simulator/simulatorLayout.js
@@ -26,7 +26,8 @@ const SimulatorGrid = styled.section`
 
   display: grid;
   grid-template-rows: 1fr ${space.controls};
-  grid-template-columns: ${space.sidebar} 1fr;
+  grid-template-columns: 1fr;
+  ${media.tablet`grid-template-columns: ${space.sidebar} 1fr;`}
   background-color: ${colour.defaultbg};
 `
 

--- a/src/features/warriorManager/warriorManagerContainer.js
+++ b/src/features/warriorManager/warriorManagerContainer.js
@@ -18,7 +18,7 @@ import {
 
 const WarriorWrapper = styled.div`
 
-  ${props => props.current && media.tablet`background-color: ${colour.lightbg};`}
+  ${props => props.current && media.desktop`background-color: ${colour.lightbg};`}
   ${props => props.current && `border-bottom: 2px solid ${colour.blue};`}
 
   height: calc(100% - 2px);
@@ -32,7 +32,7 @@ const WarriorWrapper = styled.div`
   border-left: 1px solid ${colour.defaultbg};
   position: relative;
 
-  ${media.tablet`
+  ${media.desktop`
     min-width: 100%;
     min-height: 40px;
     height: 100px;
@@ -74,7 +74,7 @@ const WarriorName = styled.span`
   padding: ${space.m} ${space.s};
   word-break: break-word;
   text-align: center;
-  ${media.tablet`
+  ${media.desktop`
     padding: 0 ${space.xs} 0 ${space.xs};
   `}
 
@@ -87,7 +87,7 @@ const NewButton = styled.div`
   display: flex;
   width: 100px;
   border-left: 2px solid ${colour.defaultbg};
-  ${media.tablet`
+  ${media.desktop`
     border: none;
     height: ${space.controls};
     width: 100%;
@@ -109,7 +109,7 @@ const WarriorManagerContainer = ({ warriors, currentWarrior, addWarrior, loadWar
   toggleWarrior, removeWarrior, currentFileIndex }) => (
   <WarriorPanel>
     <Media
-      query={{ maxWidth: sizes.tablet }}
+      query={{ maxWidth: sizes.desktop }}
       render={() => <NewButton onClick={addWarrior}>
         <Octicon name={`plus`} />
       </NewButton>}

--- a/src/features/warriorManager/warriorManagerContainer.js
+++ b/src/features/warriorManager/warriorManagerContainer.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
+import Octicon from 'react-octicon'
 
 import WarriorPanel from '../common/warriorPanel'
 
@@ -20,6 +21,10 @@ const WarriorWrapper = styled.div`
   width: 100%;
   padding: ${space.s} 0;
   border-bottom: 1px solid ${colour.lightbg};
+
+  :hover {
+    cursor: pointer;
+  }
 `
 
 const WarriorName = styled.span`
@@ -27,16 +32,19 @@ const WarriorName = styled.span`
   font-size: ${font.small};
 `
 
-const WarriorManagerContainer = ({ warriors, currentWarrior, loadWarrior, removeWarrior }) => (
+const WarriorManagerContainer = ({ warriors, currentWarrior, loadWarrior, removeWarrior, currentFileIndex }) => (
   <WarriorPanel>
     {warriors.map((warrior,i) => (
-      <WarriorWrapper key={`${warrior.hash}_${i}`}>
+      <WarriorWrapper
+        key={`${warrior.hash}_${i}`}
+        onClick={() => loadWarrior(warrior.hash, i)}
+        current={currentFileIndex === i}>
         <WarriorName>{warrior.metaData.name}</WarriorName>
+        {i > 0 && <Octicon name={`x`} onClick={() => removeWarrior(i)} />}
         <img
           src={`data:image/svg+xml;base64,${warrior.icon}`}
           alt={`${warrior.metaData.name} avatar`}
-          size={20}
-          onClick={() => loadWarrior(warrior.hash)} />
+          size={20} />
       </WarriorWrapper>
     ))}
   </WarriorPanel>
@@ -46,7 +54,8 @@ const WarriorManagerContainer = ({ warriors, currentWarrior, loadWarrior, remove
 
 const mapStateToProps = state => ({
   currentWarrior: state.parser.currentWarrior,
-  warriors: state.parser.warriors
+  warriors: state.parser.warriors,
+  currentFileIndex: state.parser.currentFileIndex
 })
 
 export default connect(

--- a/src/features/warriorManager/warriorManagerContainer.js
+++ b/src/features/warriorManager/warriorManagerContainer.js
@@ -60,12 +60,14 @@ const WarriorManagerContainer = ({ warriors, currentWarrior, addWarrior, loadWar
         key={`${warrior.hash}_${i}`}
         onClick={() => loadWarrior(warrior.hash, i)}
         current={currentFileIndex === i}
-        active={warrior.active}>
+        active={!warrior.hasErrors}>
         <WarriorName>{warrior.metaData.name}</WarriorName>
-        <img
-          src={`data:image/svg+xml;base64,${warrior.icon}`}
-          alt={`${warrior.metaData.name} avatar`}
-          size={20} />
+        {warrior.icon &&
+          <img
+            src={`data:image/svg+xml;base64,${warrior.icon}`}
+            alt={`${warrior.metaData.name} avatar`}
+            size={20} />
+        }
         <Octicon
           name={`broadcast`}
           onClick={() => toggleWarrior(i)}/>

--- a/src/features/warriorManager/warriorManagerContainer.js
+++ b/src/features/warriorManager/warriorManagerContainer.js
@@ -6,6 +6,7 @@ import Octicon from 'react-octicon'
 import WarriorPanel from '../common/warriorPanel'
 
 import { colour, font, space } from '../common/theme'
+import { media } from '../common/mediaQuery'
 
 import {
   removeWarrior,
@@ -15,15 +16,36 @@ import {
 } from '../parser/actions'
 
 const WarriorWrapper = styled.div`
-  ${props => props.current && `background-color: ${colour.lightbg};`}
-  min-height: 40px;
-  height: 120px;
+
+  ${props => props.current && media.tablet`background-color: ${colour.lightbg};`}
+  ${props => props.current && `border-bottom: 2px solid ${colour.coral};`}
+
+  height: 100%;
+  min-width: 120px;
+  width: auto;
   display: grid;
-  grid-template-columns: 1fr;
-  justify-items: center;
-  width: 100%;
-  padding: ${space.s} 0;
-  border-bottom: 1px solid ${colour.lightbg};
+  grid-template-rows: 1fr;
+  grid-template-columns: 30px 1fr 20px 20px;
+  grid-column-gap: ${space.s};
+  padding-left: ${space.s};
+  align-items: center;
+  border-left: 1px solid ${colour.defaultbg};
+  border-right: 1px solid ${colour.defaultbg};
+  position: relative;
+
+  ${media.tablet`
+    min-width: 100%;
+    min-height: 40px;
+    height: 100px;
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 30px 20px 20px;
+    grid-row-gap: ${space.s};
+    justify-items: center;
+    padding: ${space.l} 0 ${space.s} 0;
+    border-bottom: 1px solid ${colour.lightbg};
+  `}
+
 
   :hover {
     cursor: pointer;
@@ -34,6 +56,9 @@ const WarriorWrapper = styled.div`
     text-align: right;
     width: 100%;
     height: ${space.m};
+    position: absolute;
+    top: 2px;
+    right: 1px;
   }
 
   .octicon-primitive-dot {
@@ -49,8 +74,11 @@ const WarriorName = styled.span`
 `
 
 const NewButton = styled.div`
-  width: 100%;
-  height: ${space.controls};
+  width: 100px;
+  ${media.tablet`
+    height: ${space.controls};
+    width: 100%;
+  `}
   display: flex;
   align-items: center;
   justify-content: center;
@@ -75,7 +103,7 @@ const WarriorManagerContainer = ({ warriors, currentWarrior, addWarrior, loadWar
         key={`${warrior.hash}_${i}`}
         current={currentFileIndex === i}
         active={!warrior.hasErrors && warrior.active}>
-        {i > 0 && <Octicon name={`x`} onClick={() => removeWarrior(i)} />}
+
         {warrior.icon &&
           <img
             onClick={() => loadWarrior(warrior.hash, i)}
@@ -87,6 +115,7 @@ const WarriorManagerContainer = ({ warriors, currentWarrior, addWarrior, loadWar
         <Octicon
           name={`primitive-dot`}
           onClick={() => toggleWarrior(i)}/>
+        {<Octicon name={`x`} onClick={() => removeWarrior(i)} />}
       </WarriorWrapper>
     ))}
   </WarriorPanel>

--- a/src/features/warriorManager/warriorManagerContainer.js
+++ b/src/features/warriorManager/warriorManagerContainer.js
@@ -2,11 +2,12 @@ import React from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
 import Octicon from 'react-octicon'
+import Media from 'react-media'
 
 import WarriorPanel from '../common/warriorPanel'
 
 import { colour, font, space } from '../common/theme'
-import { media } from '../common/mediaQuery'
+import { media, sizes } from '../common/mediaQuery'
 
 import {
   removeWarrior,
@@ -18,19 +19,17 @@ import {
 const WarriorWrapper = styled.div`
 
   ${props => props.current && media.tablet`background-color: ${colour.lightbg};`}
-  ${props => props.current && `border-bottom: 2px solid ${colour.coral};`}
+  ${props => props.current && `border-bottom: 2px solid ${colour.blue};`}
 
-  height: 100%;
+  height: calc(100% - 2px);
   min-width: 120px;
   width: auto;
   display: grid;
   grid-template-rows: 1fr;
-  grid-template-columns: 30px 1fr 20px 20px;
-  grid-column-gap: ${space.s};
+  grid-template-columns: 30px 1fr 30px 30px;
   padding-left: ${space.s};
   align-items: center;
   border-left: 1px solid ${colour.defaultbg};
-  border-right: 1px solid ${colour.defaultbg};
   position: relative;
 
   ${media.tablet`
@@ -39,23 +38,20 @@ const WarriorWrapper = styled.div`
     height: 100px;
     display: grid;
     grid-template-columns: 1fr;
-    grid-template-rows: 30px 20px 20px;
     grid-row-gap: ${space.s};
     justify-items: center;
-    padding: ${space.l} 0 ${space.s} 0;
+    padding: ${space.m} 0 ${space.s} 0;
     border-bottom: 1px solid ${colour.lightbg};
   `}
 
-
-  :hover {
+  img:hover {
     cursor: pointer;
   }
 
   .octicon-x {
     color: ${colour.grey};
     text-align: right;
-    width: 100%;
-    height: ${space.m};
+    height: ${space.s};
     position: absolute;
     top: 2px;
     right: 1px;
@@ -65,21 +61,38 @@ const WarriorWrapper = styled.div`
     ${props => props.active ? `color: ${colour.success};` : `color: ${colour.error};`}
     font-size: ${font.large};
     padding-left: ${space.s};
+
+    :hover {
+      cursor: pointer;
+    }
   }
 `
 
 const WarriorName = styled.span`
   color: ${colour.white};
   font-size: ${font.small};
+  padding: ${space.m} ${space.s};
+  word-break: break-word;
+  text-align: center;
+  ${media.tablet`
+    padding: 0 ${space.xs} 0 ${space.xs};
+  `}
+
+  :hover {
+    cursor: pointer;
+  }
 `
 
 const NewButton = styled.div`
+  display: flex;
   width: 100px;
+  border-left: 2px solid ${colour.defaultbg};
   ${media.tablet`
+    border: none;
     height: ${space.controls};
     width: 100%;
   `}
-  display: flex;
+
   align-items: center;
   justify-content: center;
   flex-direction: row;
@@ -95,9 +108,12 @@ const NewButton = styled.div`
 const WarriorManagerContainer = ({ warriors, currentWarrior, addWarrior, loadWarrior,
   toggleWarrior, removeWarrior, currentFileIndex }) => (
   <WarriorPanel>
-    <NewButton onClick={addWarrior}>
-      <Octicon name={`plus`} />
-    </NewButton>
+    <Media
+      query={{ maxWidth: sizes.tablet }}
+      render={() => <NewButton onClick={addWarrior}>
+        <Octicon name={`plus`} />
+      </NewButton>}
+    />
     {warriors.map((warrior,i) => (
       <WarriorWrapper
         key={`${warrior.hash}_${i}`}
@@ -111,7 +127,10 @@ const WarriorManagerContainer = ({ warriors, currentWarrior, addWarrior, loadWar
             alt={`${warrior.metaData.name} avatar`}
             size={20} />
         }
-        <WarriorName>{warrior.metaData.name}</WarriorName>
+        <WarriorName
+          onClick={() => loadWarrior(warrior.hash, i)}>
+          {warrior.metaData.name}
+        </WarriorName>
         <Octicon
           name={`primitive-dot`}
           onClick={() => toggleWarrior(i)}/>

--- a/src/features/warriorManager/warriorManagerContainer.js
+++ b/src/features/warriorManager/warriorManagerContainer.js
@@ -1,0 +1,60 @@
+import React from 'react'
+import { connect } from 'react-redux'
+import styled from 'styled-components'
+
+import WarriorPanel from '../common/warriorPanel'
+
+import { colour, font, space } from '../common/theme'
+
+import {
+  removeWarrior,
+  loadWarrior
+} from '../parser/actions'
+
+const WarriorWrapper = styled.div`
+  ${props => props.current && `background-color: ${colour.lightbg};`}
+  min-height: 40px;
+  height: 100px;
+  display: grid;
+  justify-items: center;
+  width: 100%;
+  padding: ${space.s} 0;
+  border-bottom: 1px solid ${colour.lightbg};
+`
+
+const WarriorName = styled.span`
+  color: ${colour.white};
+  font-size: ${font.small};
+`
+
+const WarriorManagerContainer = ({ warriors, currentWarrior, loadWarrior, removeWarrior }) => (
+  <WarriorPanel>
+    {warriors.map((warrior,i) => (
+      <WarriorWrapper key={`${warrior.hash}_${i}`}>
+        <WarriorName>{warrior.metaData.name}</WarriorName>
+        <img
+          src={`data:image/svg+xml;base64,${warrior.icon}`}
+          alt={`${warrior.metaData.name} avatar`}
+          size={20}
+          onClick={() => loadWarrior(warrior.hash)} />
+      </WarriorWrapper>
+    ))}
+  </WarriorPanel>
+
+)
+
+
+const mapStateToProps = state => ({
+  currentWarrior: state.parser.currentWarrior,
+  warriors: state.parser.warriors
+})
+
+export default connect(
+  mapStateToProps,
+  {
+    removeWarrior,
+    loadWarrior
+  }
+)(WarriorManagerContainer)
+
+export { WarriorManagerContainer as PureWarriorManagerContainer }

--- a/src/features/warriorManager/warriorManagerContainer.js
+++ b/src/features/warriorManager/warriorManagerContainer.js
@@ -17,7 +17,7 @@ import {
 const WarriorWrapper = styled.div`
   ${props => props.current && `background-color: ${colour.lightbg};`}
   min-height: 40px;
-  height: 100px;
+  height: 120px;
   display: grid;
   grid-template-columns: 1fr;
   justify-items: center;
@@ -29,7 +29,14 @@ const WarriorWrapper = styled.div`
     cursor: pointer;
   }
 
-  .octicon-broadcast {
+  .octicon-x {
+    color: ${colour.grey};
+    text-align: right;
+    width: 100%;
+    height: ${space.m};
+  }
+
+  .octicon-heart {
     ${props => props.active ? `color: ${colour.blue};` : `color: ${colour.coral};`}
   }
 `
@@ -41,12 +48,18 @@ const WarriorName = styled.span`
 
 const NewButton = styled.div`
   width: 100%;
+  height: ${space.controls};
   display: flex;
   align-items: center;
   justify-content: center;
   flex-direction: row;
   flex-wrap: wrap;
+  text-align: center;
   color: ${colour.white};
+
+  :hover {
+    cursor: pointer;
+  }
 `
 
 const WarriorManagerContainer = ({ warriors, currentWarrior, addWarrior, loadWarrior,
@@ -61,17 +74,17 @@ const WarriorManagerContainer = ({ warriors, currentWarrior, addWarrior, loadWar
         onClick={() => loadWarrior(warrior.hash, i)}
         current={currentFileIndex === i}
         active={!warrior.hasErrors}>
-        <WarriorName>{warrior.metaData.name}</WarriorName>
+        {i > 0 && <Octicon name={`x`} onClick={() => removeWarrior(i)} />}
         {warrior.icon &&
           <img
             src={`data:image/svg+xml;base64,${warrior.icon}`}
             alt={`${warrior.metaData.name} avatar`}
             size={20} />
         }
+        <WarriorName>{warrior.metaData.name}</WarriorName>
         <Octicon
-          name={`broadcast`}
+          name={`heart`}
           onClick={() => toggleWarrior(i)}/>
-        {i > 0 && <Octicon name={`x`} onClick={() => removeWarrior(i)} />}
       </WarriorWrapper>
     ))}
   </WarriorPanel>

--- a/src/features/warriorManager/warriorManagerContainer.js
+++ b/src/features/warriorManager/warriorManagerContainer.js
@@ -9,7 +9,9 @@ import { colour, font, space } from '../common/theme'
 
 import {
   removeWarrior,
-  loadWarrior
+  loadWarrior,
+  addWarrior,
+  toggleWarrior
 } from '../parser/actions'
 
 const WarriorWrapper = styled.div`
@@ -17,6 +19,7 @@ const WarriorWrapper = styled.div`
   min-height: 40px;
   height: 100px;
   display: grid;
+  grid-template-columns: 1fr;
   justify-items: center;
   width: 100%;
   padding: ${space.s} 0;
@@ -25,6 +28,10 @@ const WarriorWrapper = styled.div`
   :hover {
     cursor: pointer;
   }
+
+  .octicon-broadcast {
+    ${props => props.active ? `color: ${colour.blue};` : `color: ${colour.coral};`}
+  }
 `
 
 const WarriorName = styled.span`
@@ -32,19 +39,37 @@ const WarriorName = styled.span`
   font-size: ${font.small};
 `
 
-const WarriorManagerContainer = ({ warriors, currentWarrior, loadWarrior, removeWarrior, currentFileIndex }) => (
+const NewButton = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: row;
+  flex-wrap: wrap;
+  color: ${colour.white};
+`
+
+const WarriorManagerContainer = ({ warriors, currentWarrior, addWarrior, loadWarrior,
+  toggleWarrior, removeWarrior, currentFileIndex }) => (
   <WarriorPanel>
+    <NewButton onClick={addWarrior}>
+      <Octicon name={`plus`} />
+    </NewButton>
     {warriors.map((warrior,i) => (
       <WarriorWrapper
         key={`${warrior.hash}_${i}`}
         onClick={() => loadWarrior(warrior.hash, i)}
-        current={currentFileIndex === i}>
+        current={currentFileIndex === i}
+        active={warrior.active}>
         <WarriorName>{warrior.metaData.name}</WarriorName>
-        {i > 0 && <Octicon name={`x`} onClick={() => removeWarrior(i)} />}
         <img
           src={`data:image/svg+xml;base64,${warrior.icon}`}
           alt={`${warrior.metaData.name} avatar`}
           size={20} />
+        <Octicon
+          name={`broadcast`}
+          onClick={() => toggleWarrior(i)}/>
+        {i > 0 && <Octicon name={`x`} onClick={() => removeWarrior(i)} />}
       </WarriorWrapper>
     ))}
   </WarriorPanel>
@@ -61,8 +86,10 @@ const mapStateToProps = state => ({
 export default connect(
   mapStateToProps,
   {
+    addWarrior,
     removeWarrior,
-    loadWarrior
+    loadWarrior,
+    toggleWarrior
   }
 )(WarriorManagerContainer)
 

--- a/src/features/warriorManager/warriorManagerContainer.js
+++ b/src/features/warriorManager/warriorManagerContainer.js
@@ -73,12 +73,12 @@ const WarriorManagerContainer = ({ warriors, currentWarrior, addWarrior, loadWar
     {warriors.map((warrior,i) => (
       <WarriorWrapper
         key={`${warrior.hash}_${i}`}
-        onClick={() => loadWarrior(warrior.hash, i)}
         current={currentFileIndex === i}
         active={!warrior.hasErrors && warrior.active}>
         {i > 0 && <Octicon name={`x`} onClick={() => removeWarrior(i)} />}
         {warrior.icon &&
           <img
+            onClick={() => loadWarrior(warrior.hash, i)}
             src={`data:image/svg+xml;base64,${warrior.icon}`}
             alt={`${warrior.metaData.name} avatar`}
             size={20} />

--- a/src/features/warriorManager/warriorManagerContainer.js
+++ b/src/features/warriorManager/warriorManagerContainer.js
@@ -36,8 +36,10 @@ const WarriorWrapper = styled.div`
     height: ${space.m};
   }
 
-  .octicon-heart {
-    ${props => props.active ? `color: ${colour.blue};` : `color: ${colour.coral};`}
+  .octicon-primitive-dot {
+    ${props => props.active ? `color: ${colour.success};` : `color: ${colour.error};`}
+    font-size: ${font.large};
+    padding-left: ${space.s};
   }
 `
 
@@ -73,7 +75,7 @@ const WarriorManagerContainer = ({ warriors, currentWarrior, addWarrior, loadWar
         key={`${warrior.hash}_${i}`}
         onClick={() => loadWarrior(warrior.hash, i)}
         current={currentFileIndex === i}
-        active={!warrior.hasErrors}>
+        active={!warrior.hasErrors && warrior.active}>
         {i > 0 && <Octicon name={`x`} onClick={() => removeWarrior(i)} />}
         {warrior.icon &&
           <img
@@ -83,7 +85,7 @@ const WarriorManagerContainer = ({ warriors, currentWarrior, addWarrior, loadWar
         }
         <WarriorName>{warrior.metaData.name}</WarriorName>
         <Octicon
-          name={`heart`}
+          name={`primitive-dot`}
           onClick={() => toggleWarrior(i)}/>
       </WarriorWrapper>
     ))}

--- a/src/helpers/arrayHelpers.js
+++ b/src/helpers/arrayHelpers.js
@@ -13,15 +13,8 @@ export const removeItem = (index, array) => {
 
 export const replaceItem = (index, array, item) => {
 
-    return array.map((el, i) => {
-      if(i !== index) {
-        return el;
-      }
-
-      return {
-        ...el,
-        ...item
-      }
-    })
+    const removedList = removeItem(index, array)
+    const addedList = insertItem(index, removedList, item)
+    return addedList
 
 }

--- a/src/helpers/newWarrior.js
+++ b/src/helpers/newWarrior.js
@@ -2,7 +2,7 @@ import { getIdenticon } from '../features/common/identicon'
 
 const blankSource = ''
 
-const icon = getIdenticon(blankSource, 0)
+const icon = getIdenticon(blankSource, 0, 20)
 
 const newWarrior = {
   active: true,

--- a/src/helpers/newWarrior.js
+++ b/src/helpers/newWarrior.js
@@ -5,9 +5,10 @@ const blankSource = ''
 const icon = getIdenticon(blankSource, 0)
 
 const newWarrior = {
+  active: true,
   source: blankSource,
   compiled: '',
-  hasErrors: false,
+  hasErrors: true,
   hash: '',
   icon: icon,
   metaData: {

--- a/src/helpers/newWarrior.js
+++ b/src/helpers/newWarrior.js
@@ -1,0 +1,20 @@
+import { getIdenticon } from '../features/common/identicon'
+
+const blankSource = ''
+
+const icon = getIdenticon(blankSource, 0)
+
+const newWarrior = {
+  source: blankSource,
+  compiled: '',
+  hasErrors: false,
+  hash: '',
+  icon: icon,
+  metaData: {
+    name: 'Nameless',
+    author: 'Blameless'
+  },
+  tokens: []
+}
+
+export default newWarrior


### PR DESCRIPTION
This adds in horizontal tabs on desktop and vertical tabs / buttons on mobile to represent the warrior files you have open.

- [x] `add to core` functionality has been removed
- [x] live parsing / core initing is implemented 
- [x] toggling of warriors in and out of the core is added
- [x] click on an icon or name to select the warrior you want to edit

**Desktop**

![image](https://user-images.githubusercontent.com/1190042/37555515-1edf6440-29e0-11e8-81ac-bb915421dd1a.png)

**Mobile**

![image](https://user-images.githubusercontent.com/1190042/37555523-3bb70c44-29e0-11e8-866b-309452d310db.png)

Fixes #33 
Fixes #118 