### PR TITLE
add fast-json-stable-stringify dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "license": "MIT",
   "dependencies": {
     "corewar": "0.0.74",
+    "fast-json-stable-stringify": "^2.0.0",
     "fetch-jsonp": "^1.1.3",
     "identicon.js": "^2.3.1",
     "immutable": "^3.8.2",


### PR DESCRIPTION
This was missing from `package.json` and broke `npm i` for me.